### PR TITLE
Update lineStart when lineNumber is incremented in scanXJSText

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -5179,6 +5179,7 @@ parseYieldExpression: true
                 ch = source[index++];
                 if (isLineTerminator(ch.charCodeAt(0))) {
                     ++lineNumber;
+                    lineStart = index;
                 }
                 str += ch;
             }

--- a/test/test.js
+++ b/test/test.js
@@ -23164,6 +23164,7 @@ var testFixture = {
                 }
             }
         },
+
         '<AbC-def\n  test="&#x0026;&#38;">\nbar\nbaz\n</AbC-def>': {
             type: "ExpressionStatement",
             expression: {
@@ -23291,11 +23292,11 @@ var testFixture = {
                         loc: {
                             start: {
                                 line: 5,
-                                column: 34
+                                column: 2
                             },
                             end: {
                                 line: 5,
-                                column: 41
+                                column: 9
                             }
                         }
                     },
@@ -23306,11 +23307,11 @@ var testFixture = {
                     loc: {
                         start: {
                             line: 5,
-                            column: 32
+                            column: 0
                         },
                         end: {
                             line: 5,
-                            column: 42
+                            column: 10
                         }
                     }
                 },
@@ -23386,7 +23387,7 @@ var testFixture = {
                             },
                             end: {
                                 line: 5,
-                                column: 32
+                                column: 0
                             }
                         }
                     }
@@ -23402,7 +23403,7 @@ var testFixture = {
                     },
                     end: {
                         line: 5,
-                        column: 42
+                        column: 10
                     }
                 }
             },
@@ -23417,10 +23418,11 @@ var testFixture = {
                 },
                 end: {
                     line: 5,
-                    column: 42
+                    column: 10
                 }
             }
         },
+
         '<a b={x ? <c /> : <d />} />': {
             type: "ExpressionStatement",
             expression: {


### PR DESCRIPTION
This bug causes `loc.{start,end}.column` values to become much larger than they should be as more and more lines are parsed.

cc @jeffmo
