### PR TITLE
Allow dot (.) in JSXIdentifier to allow for Javascript "namespacing"

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -5106,7 +5106,8 @@ parseYieldExpression: true
 
     function isXJSIdentifierPart(ch) {
         // exclude backslash (\) and add hyphen (-)
-        return (ch !== 92) && (ch === 45 || isIdentifierPart(ch));
+        // add dot (.) for javascript tag "namespacing", like in <App.Templates.Counter />
+        return (ch !== 92) && (ch === 45 || ch === 46 || isIdentifierPart(ch));
     }
 
     function scanXJSIdentifier() {


### PR DESCRIPTION
This is PR for https://github.com/facebook/react/issues/221, basically we would love to have 

``` javascript
<Namespaced.JSX.Tags /> 
```

We probably need to add tests here, can owner comment on that?
