### PR TITLE
Simple fix to support IE8 (and earlier?), intended for React's JSXTransformer

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -2079,7 +2079,7 @@ parseYieldExpression: true
             return {
                 type: Syntax.ExportDeclaration,
                 declaration: declaration,
-                default: def,
+                'default': def,
                 specifiers: specifiers,
                 source: source
             };


### PR DESCRIPTION
This is one of the few issues preventing IE8 from also running the JSXTransformer in-browser (https://github.com/facebook/react/pull/484).
