### PR TITLE
Allow dots in XJS identifiers <com.tag />

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -5217,8 +5217,8 @@ parseYieldExpression: true
     }
 
     function isXJSIdentifierPart(ch) {
-        // exclude backslash (\) and add hyphen (-)
-        return (ch !== 92) && (ch === 45 || isIdentifierPart(ch));
+        // exclude backslash (\) and add hyphen (-) and add dot (.)
+        return (ch !== 92) && (ch === 45 || ch === 46 || isIdentifierPart(ch));
     }
 
     function scanXJSIdentifier() {


### PR DESCRIPTION
I feel like this would be a natural fit for React, for those who may prefer not to use CommonJS-style imports. It simply adds the ability to use dots in tags like `<com.xjs.tag />` and translates straight to JS.

A side-effect of this is that it also allows dots in attribute names (both are XJS-identifiers), which may or may not be useful. However, hyphens are currently allowed (for attributes I assume), they however produce an error when used in XJS-tags (JS interprets it as subtraction).

I'm personally not _in need_ of this, it's simply a suggestion.
