### PR TITLE
Slightly improve error when forgetting `=` in attr

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -2190,7 +2190,7 @@ parseYieldExpression: true
             throwError(token, Messages.UnexpectedNumber);
         }
 
-        if (token.type === Token.StringLiteral) {
+        if (token.type === Token.StringLiteral || token.type === Token.XJSText) {
             throwError(token, Messages.UnexpectedString);
         }
 

--- a/test/fbtest.js
+++ b/test/fbtest.js
@@ -1517,6 +1517,14 @@ var fbTestFixture = {
             column: 20,
             message: 'Error: Line 1: Unexpected token ,',
             description: 'Unexpected token ,'
+        },
+
+        '<div className"app">': {
+            index: 14,
+            lineNumber: 1,
+            column: 15,
+            message: 'Error: Line 1: Unexpected string',
+            description: 'Unexpected string'
         }
     },
 


### PR DESCRIPTION
Improves facebook/react#917.

Now, `<div className"app">` gives 'Unexpected string' instead of 'Unexpected
token app'.
