### PR TITLE
Fix ComprehensionBlock and prevent that from happening in the future.

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -5082,6 +5082,7 @@ parseYieldExpression: true
             extra.parseClassDeclaration = parseClassDeclaration;
             extra.parseClassExpression = parseClassExpression;
             extra.parseClassBody = parseClassBody;
+            extra.parseForStatement = parseForStatement;
 
             parseArrayInitialiser = wrapTracking(extra.parseArrayInitialiser);
             parseAssignmentExpression = wrapTracking(extra.parseAssignmentExpression);
@@ -5125,6 +5126,7 @@ parseYieldExpression: true
             parseClassDeclaration = wrapTracking(extra.parseClassDeclaration);
             parseClassExpression = wrapTracking(extra.parseClassExpression);
             parseClassBody = wrapTracking(extra.parseClassBody);
+            parseForStatement = wrapTracking(extra.parseForStatement);
         }
 
         if (typeof extra.tokens !== 'undefined') {
@@ -5186,6 +5188,7 @@ parseYieldExpression: true
             parseClassDeclaration = extra.parseClassDeclaration;
             parseClassExpression = extra.parseClassExpression;
             parseClassBody = extra.parseClassBody;
+            parseForStatement = extra.parseForStatement;
         }
 
         if (typeof extra.scanRegExp === 'function') {

--- a/test/harmonytest.js
+++ b/test/harmonytest.js
@@ -2823,6 +2823,11 @@ var harmonyTestFixture = {
                         }
                     },
                     each: false,
+                    range: [9, 22],
+                    loc: {
+                        start: { line: 1, column: 9 },
+                        end: { line: 1, column: 22 }
+                    },
                     of: false
                 }, {
                     type: 'ComprehensionBlock',
@@ -2845,6 +2850,11 @@ var harmonyTestFixture = {
                         }
                     },
                     each: false,
+                    range: [23, 36],
+                    loc: {
+                        start: { line: 1, column: 23 },
+                        end: { line: 1, column: 36 }
+                    },
                     of: false
                 }],
                 body: {
@@ -2919,6 +2929,11 @@ var harmonyTestFixture = {
                         }
                     },
                     each: false,
+                    range: [3, 16],
+                    loc: {
+                        start: { line: 1, column: 3 },
+                        end: { line: 1, column: 16 }
+                    },
                     of: false
                 }],
                 body: {
@@ -2969,6 +2984,11 @@ var harmonyTestFixture = {
                         }
                     },
                     each: false,
+                    range: [3, 16],
+                    loc: {
+                        start: { line: 1, column: 3 },
+                        end: { line: 1, column: 16 }
+                    },
                     of: false
                 }],
                 body: {
@@ -3020,6 +3040,11 @@ var harmonyTestFixture = {
                         }
                     },
                     each: false,
+                    range: [7, 20],
+                    loc: {
+                        start: { line: 1, column: 7 },
+                        end: { line: 1, column: 20 }
+                    },
                     of: false
                 }],
                 body: {
@@ -3086,6 +3111,11 @@ var harmonyTestFixture = {
                             start: { line: 1, column: 13 },
                             end: { line: 1, column: 18 }
                         }
+                    },
+                    range: [3, 19],
+                    loc: {
+                        start: { line: 1, column: 3 },
+                        end: { line: 1, column: 19 }
                     },
                     of: true
                 }],
@@ -3162,6 +3192,11 @@ var harmonyTestFixture = {
                             end: { line: 1, column: 18 }
                         }
                     },
+                    range: [3, 19],
+                    loc: {
+                        start: { line: 1, column: 3 },
+                        end: { line: 1, column: 19 }
+                    },
                     of: true
                 }, {
                     type: 'ComprehensionBlock',
@@ -3182,6 +3217,11 @@ var harmonyTestFixture = {
                             start: { line: 1, column: 30 },
                             end: { line: 1, column: 36 }
                         }
+                    },
+                    range: [20, 37],
+                    loc: {
+                        start: { line: 1, column: 20 },
+                        end: { line: 1, column: 37 }
                     },
                     of: true
                 }],
@@ -12092,7 +12132,7 @@ var harmonyTestFixture = {
             index: 34,
             lineNumber: 1,
             column: 35,
-            message: 'Error: Line 1: Parameter name eval or arguments is not allowed in strict mode'            
+            message: 'Error: Line 1: Parameter name eval or arguments is not allowed in strict mode'
         },
 
         '(a, a) => 42': {


### PR DESCRIPTION
Summary: https://code.google.com/p/esprima/issues/detail?id=505
Added a unit test the ensures that all nodes with 'type' have loc/range
(when it's enabled).

Test Plan: npm test
