### PR TITLE
Exclude all tests from npm package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,15 @@
         "esvalidate": "./bin/esvalidate.js"
     },
     "version": "1.1.0-dev",
+    "files": [
+        "bin",
+        "test/run.js",
+        "test/runner.js",
+        "test/test.js",
+        "test/compat.js",
+        "test/reflect.js",
+        "esprima.js"
+    ],
     "engines": {
         "node": ">=0.4.0"
     },


### PR DESCRIPTION
See: substack/node-browserify#707

This reduces the size of the installed module by ~1.8MB, improving overall install times for dependant modules – made more significant by the fact that there's multiple copies of esprima-fb being installed with larger projects e.g. browserify.

Thanks! :)
