### PR TITLE
XJSNamespacedName to replace namespace in XJSIdentifier token

### DIFF
--- a/test/fbtest.js
+++ b/test/fbtest.js
@@ -39,47 +39,77 @@ var fbTestFixture = {
             }
         },
         '<n:a n:v />': {
-            type: "ExpressionStatement",
+            type: 'ExpressionStatement',
             expression: {
-                type: "XJSElement",
+                type: 'XJSElement',
                 openingElement: {
-                  type: "XJSOpeningElement",
-                  name: {
-                      type: "XJSIdentifier",
-                      name: "a",
-                      namespace: "n",
-                      range: [1, 4],
-                      loc: {
-                          start: { line: 1, column: 1 },
-                          end: { line: 1, column: 4 }
-                      }
-                  },
-                  selfClosing: true,
-                  attributes: [
-                      {
-                          type: "XJSAttribute",
-                          name: {
-                              type: "XJSIdentifier",
-                              name: "v",
-                              namespace: "n",
-                              range: [5, 8],
-                              loc: {
-                                  start: { line: 1, column: 5 },
-                                  end: { line: 1, column: 8 }
-                              }
-                          },
-                          range: [5, 8],
-                          loc: {
-                              start: { line: 1, column: 5 },
-                              end: { line: 1, column: 8 }
-                          }
-                      }
-                  ],
-                  range: [0, 11],
-                  loc: {
-                      start: { line: 1, column: 0 },
-                      end: { line: 1, column: 11 }
-                  }
+                    type: 'XJSOpeningElement',
+                    name: {
+                        type: 'XJSNamespacedName',
+                        namespace: {
+                            type: 'XJSIdentifier',
+                            name: 'n',
+                            range: [1, 2],
+                            loc: {
+                                start: { line: 1, column: 1 },
+                                end: { line: 1, column: 2 }
+                            }
+                        },
+                        name: {
+                            type: 'XJSIdentifier',
+                            name: 'a',
+                            range: [3, 4],
+                            loc: {
+                                start: { line: 1, column: 3 },
+                                end: { line: 1, column: 4 }
+                            }
+                        },
+                        range: [1, 4],
+                        loc: {
+                            start: { line: 1, column: 1 },
+                            end: { line: 1, column: 4 }
+                        }
+                    },
+                    selfClosing: true,
+                    attributes: [{
+                        type: 'XJSAttribute',
+                        name: {
+                            type: 'XJSNamespacedName',
+                            namespace: {
+                                type: 'XJSIdentifier',
+                                name: 'n',
+                                range: [5, 6],
+                                loc: {
+                                    start: { line: 1, column: 5 },
+                                    end: { line: 1, column: 6 }
+                                }
+                            },
+                            name: {
+                                type: 'XJSIdentifier',
+                                name: 'v',
+                                range: [7, 8],
+                                loc: {
+                                    start: { line: 1, column: 7 },
+                                    end: { line: 1, column: 8 }
+                                }
+                            },
+                            range: [5, 8],
+                            loc: {
+                                start: { line: 1, column: 5 },
+                                end: { line: 1, column: 8 }
+                            }
+                        },
+                        range: [5, 8],
+                        loc: {
+                            start: { line: 1, column: 5 },
+                            end: { line: 1, column: 8 }
+                        }
+                    }],
+                    range: [0, 11],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 11 }
+                    }
                 },
                 children: [],
                 range: [0, 11],
@@ -95,14 +125,14 @@ var fbTestFixture = {
             }
         },
         '<a n:foo="bar"> {value} <b><c /></b></a>': {
-            type: "ExpressionStatement",
+            type: 'ExpressionStatement',
             expression: {
-                type: "XJSElement",
+                type: 'XJSElement',
                 openingElement: {
-                    type: "XJSOpeningElement",
+                    type: 'XJSOpeningElement',
                     name: {
-                        type: "XJSIdentifier",
-                        name: "a",
+                        type: 'XJSIdentifier',
+                        name: 'a',
                         range: [1, 2],
                         loc: {
                             start: { line: 1, column: 1 },
@@ -110,36 +140,50 @@ var fbTestFixture = {
                         }
                     },
                     selfClosing: false,
-                    attributes: [
-                        {
-                            type: "XJSAttribute",
-                            name: {
-                                type: "XJSIdentifier",
-                                name: "foo",
-                                namespace: "n",
-                                range: [3, 8],
+                    attributes: [{
+                        type: 'XJSAttribute',
+                        name: {
+                            type: 'XJSNamespacedName',
+                            namespace: {
+                                type: 'XJSIdentifier',
+                                name: 'n',
+                                range: [3, 4],
                                 loc: {
                                     start: { line: 1, column: 3 },
+                                    end: { line: 1, column: 4 }
+                                }
+                            },
+                            name: {
+                                type: 'XJSIdentifier',
+                                name: 'foo',
+                                range: [5, 8],
+                                loc: {
+                                    start: { line: 1, column: 5 },
                                     end: { line: 1, column: 8 }
                                 }
                             },
-                            value: {
-                                type: "Literal",
-                                value: "bar",
-                                raw: "\"bar\"",
-                                range: [9, 14],
-                                loc: {
-                                    start: { line: 1, column: 9 },
-                                    end: { line: 1, column: 14 }
-                                }
-                            },
-                            range: [3, 14],
+                            range: [3, 8],
                             loc: {
                                 start: { line: 1, column: 3 },
+                                end: { line: 1, column: 8 }
+                            }
+                        },
+                        value: {
+                            type: 'Literal',
+                            value: 'bar',
+                            raw: '"bar"',
+                            range: [9, 14],
+                            loc: {
+                                start: { line: 1, column: 9 },
                                 end: { line: 1, column: 14 }
                             }
+                        },
+                        range: [3, 14],
+                        loc: {
+                            start: { line: 1, column: 3 },
+                            end: { line: 1, column: 14 }
                         }
-                    ],
+                    }],
                     range: [0, 15],
                     loc: {
                         start: { line: 1, column: 0 },
@@ -147,10 +191,10 @@ var fbTestFixture = {
                     }
                 },
                 closingElement: {
-                    type: "XJSClosingElement",
+                    type: 'XJSClosingElement',
                     name: {
-                        type: "XJSIdentifier",
-                        name: "a",
+                        type: 'XJSIdentifier',
+                        name: 'a',
                         range: [38, 39],
                         loc: {
                             start: { line: 1, column: 38 },
@@ -163,119 +207,112 @@ var fbTestFixture = {
                         end: { line: 1, column: 40 }
                     }
                 },
-                children: [
-                    {
-                        type: "Literal",
-                        value: " ",
-                        raw: " ",
-                        range: [15, 16],
+                children: [{
+                    type: 'Literal',
+                    value: ' ',
+                    raw: ' ',
+                    range: [15, 16],
+                    loc: {
+                        start: { line: 1, column: 15 },
+                        end: { line: 1, column: 16 }
+                    }
+                }, {
+                    type: 'XJSExpressionContainer',
+                    expression: {
+                        type: 'Identifier',
+                        name: 'value',
+                        range: [17, 22],
                         loc: {
-                            start: { line: 1, column: 15 },
-                            end: { line: 1, column: 16 }
+                            start: { line: 1, column: 17 },
+                            end: { line: 1, column: 22 }
                         }
                     },
-                    {
-                        type: "XJSExpressionContainer",
-                        expression: {
-                            type: "Identifier",
-                            name: "value",
-                            range: [17, 22],
+                    range: [16, 23],
+                    loc: {
+                        start: { line: 1, column: 16 },
+                        end: { line: 1, column: 23 }
+                    }
+                }, {
+                    type: 'Literal',
+                    value: ' ',
+                    raw: ' ',
+                    range: [23, 24],
+                    loc: {
+                        start: { line: 1, column: 23 },
+                        end: { line: 1, column: 24 }
+                    }
+                }, {
+                    type: 'XJSElement',
+                    openingElement: {
+                        type: 'XJSOpeningElement',
+                        name: {
+                            type: 'XJSIdentifier',
+                            name: 'b',
+                            range: [25, 26],
                             loc: {
-                                start: { line: 1, column: 17 },
-                                end: { line: 1, column: 22 }
+                                start: { line: 1, column: 25 },
+                                end: { line: 1, column: 26 }
                             }
                         },
-                        range: [16, 23],
-                        loc: {
-                            start: { line: 1, column: 16 },
-                            end: { line: 1, column: 23 }
-                        }
-                    },
-                    {
-                        type: "Literal",
-                        value: " ",
-                        raw: " ",
-                        range: [23, 24],
-                        loc: {
-                            start: { line: 1, column: 23 },
-                            end: { line: 1, column: 24 }
-                        }
-                    },
-                    {
-                        type: "XJSElement",
-                        openingElement: {
-                            type: "XJSOpeningElement",
-                            name: {
-                                type: "XJSIdentifier",
-                                name: "b",
-                                range: [25, 26],
-                                loc: {
-                                    start: { line: 1, column: 25 },
-                                    end: { line: 1, column: 26 }
-                                }
-                            },
-                            selfClosing: false,
-                            attributes: [],
-                            range: [24, 27],
-                            loc: {
-                                start: { line: 1, column: 24 },
-                                end: { line: 1, column: 27 }
-                            }
-                        },
-                        closingElement: {
-                            type: "XJSClosingElement",
-                            name: {
-                                type: "XJSIdentifier",
-                                name: "b",
-                                range: [34, 35],
-                                loc: {
-                                    start: { line: 1, column: 34 },
-                                    end: { line: 1, column: 35 }
-                                }
-                            },
-                            range: [32, 36],
-                            loc: {
-                                start: { line: 1, column: 32 },
-                                end: { line: 1, column: 36 }
-                            }
-                        },
-                        children: [
-                            {
-                                type: "XJSElement",
-                                openingElement: {
-                                    type: "XJSOpeningElement",
-                                    name: {
-                                        type: "XJSIdentifier",
-                                        name: "c",
-                                        range: [28, 29],
-                                        loc: {
-                                            start: { line: 1, column: 28 },
-                                            end: { line: 1, column: 29 }
-                                        }
-                                    },
-                                    selfClosing: true,
-                                    attributes: [],
-                                    range: [27, 32],
-                                    loc: {
-                                        start: { line: 1, column: 27 },
-                                        end: { line: 1, column: 32 }
-                                    }
-                                },
-                                children: [],
-                                range: [27, 32],
-                                loc: {
-                                    start: { line: 1, column: 27 },
-                                    end: { line: 1, column: 32 }
-                                }
-                            }
-                        ],
-                        range: [24, 36],
+                        selfClosing: false,
+                        attributes: [],
+                        range: [24, 27],
                         loc: {
                             start: { line: 1, column: 24 },
+                            end: { line: 1, column: 27 }
+                        }
+                    },
+                    closingElement: {
+                        type: 'XJSClosingElement',
+                        name: {
+                            type: 'XJSIdentifier',
+                            name: 'b',
+                            range: [34, 35],
+                            loc: {
+                                start: { line: 1, column: 34 },
+                                end: { line: 1, column: 35 }
+                            }
+                        },
+                        range: [32, 36],
+                        loc: {
+                            start: { line: 1, column: 32 },
                             end: { line: 1, column: 36 }
                         }
+                    },
+                    children: [{
+                        type: 'XJSElement',
+                        openingElement: {
+                            type: 'XJSOpeningElement',
+                            name: {
+                                type: 'XJSIdentifier',
+                                name: 'c',
+                                range: [28, 29],
+                                loc: {
+                                    start: { line: 1, column: 28 },
+                                    end: { line: 1, column: 29 }
+                                }
+                            },
+                            selfClosing: true,
+                            attributes: [],
+                            range: [27, 32],
+                            loc: {
+                                start: { line: 1, column: 27 },
+                                end: { line: 1, column: 32 }
+                            }
+                        },
+                        children: [],
+                        range: [27, 32],
+                        loc: {
+                            start: { line: 1, column: 27 },
+                            end: { line: 1, column: 32 }
+                        }
+                    }],
+                    range: [24, 36],
+                    loc: {
+                        start: { line: 1, column: 24 },
+                        end: { line: 1, column: 36 }
                     }
-                ],
+                }],
                 range: [0, 40],
                 loc: {
                     start: { line: 1, column: 0 },
@@ -1959,18 +1996,17 @@ var fbTestFixture = {
         },
 
         '<a: />': {
-            index: 3,
+            index: 4,
             lineNumber: 1,
-            column: 4,
-            message: 'Error: Line 1: XJS tag name can not be empty'
+            column: 5,
+            message: 'Error: Line 1: Unexpected token /'
         },
 
         '<:a />': {
             index: 1,
             lineNumber: 1,
             column: 2,
-            message: 'Error: Line 1: Unexpected token :',
-            description: 'Unexpected token :'
+            message: 'Error: Line 1: Unexpected token :'
         },
 
         '<a b=d />': {
@@ -2012,14 +2048,14 @@ var fbTestFixture = {
             index: 4,
             lineNumber: 1,
             column: 5,
-            message: 'Error: Line 1: XJS member expressions does not support namespaces'
+            message: 'Error: Line 1: Unexpected token .'
         },
 
         '<a.b:c></a.b:c>': {
-            index: 6,
+            index: 4,
             lineNumber: 1,
-            column: 7,
-            message: 'Error: Line 1: XJS member expressions does not support namespaces'
+            column: 5,
+            message: 'Error: Line 1: Unexpected token :'
         },
 
         '<a.b.c></a>': {

--- a/test/test.js
+++ b/test/test.js
@@ -19567,6 +19567,7 @@ var testFixture = {
                 WhileStatement: 'WhileStatement',
                 WithStatement: 'WithStatement',
                 XJSIdentifier: 'XJSIdentifier',
+                XJSNamespacedName: 'XJSNamespacedName',
                 XJSMemberExpression: "XJSMemberExpression",
                 XJSEmptyExpression: "XJSEmptyExpression",
                 XJSExpressionContainer: "XJSExpressionContainer",


### PR DESCRIPTION
Follow-up to https://github.com/facebook/esprima/pull/7

As usual, just shout if there's anything you disagree with or want done differently.

I'm kind of inclined to change `XJSIdentifier.name` to `XJSIdentifier.value` to signify that it's actually a value now, `name` kind of suggests that it is an object. Also, using `XJSIdentifier.value` would make it distinct from `XJSNamespacedName.name`. But it's a rather disruptive change.

PS. http://stackoverflow.com/questions/5308816/how-to-use-git-merge-squash, although I think it will squash the commit messages too, which is not desirable.
