### PR TITLE
Fixes for parsing JSX tokens array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-coverage
+/node_modules
+/coverage

--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
     "name": "esprima",
-    "version": "4001.0001.0000-dev-harmony-fb",
+    "version": "4001.0002.0000-dev-harmony-fb",
     "main": "./esprima.js",
     "dependencies": {},
     "repository": {

--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
     "name": "esprima",
-    "version": "3001.0001.0000-dev-harmony-fb",
+    "version": "4001.0001.0000-dev-harmony-fb",
     "main": "./esprima.js",
     "dependencies": {},
     "repository": {

--- a/esprima.js
+++ b/esprima.js
@@ -5638,7 +5638,6 @@ parseYieldExpression: true
                     break;
                 }
                 state.inXJSChild = true;
-                peek(); // reset lookahead token
                 children.push(parseXJSChild());
             }
             state.inXJSChild = origInXJSChild;

--- a/esprima.js
+++ b/esprima.js
@@ -5997,7 +5997,7 @@ parseYieldExpression: true
     }
 
     // Sync with *.json manifests.
-    exports.version = '3001.0001.0000-dev-harmony-fb';
+    exports.version = '4001.0001.0000-dev-harmony-fb';
 
     exports.tokenize = tokenize;
 

--- a/esprima.js
+++ b/esprima.js
@@ -5383,7 +5383,7 @@ parseYieldExpression: true
             if (ch === '&') {
                 str += scanXJSEntity();
             } else {
-                ch = source[index++];
+                index++;
                 if (isLineTerminator(ch.charCodeAt(0))) {
                     ++lineNumber;
                     lineStart = index;
@@ -5668,7 +5668,10 @@ parseYieldExpression: true
     function collectToken() {
         var start, loc, token, range, value;
 
-        skipComment();
+        if (!state.inXJSChild) {
+            skipComment();
+        }
+
         start = index;
         loc = {
             start: {

--- a/esprima.js
+++ b/esprima.js
@@ -5999,7 +5999,7 @@ parseYieldExpression: true
     }
 
     // Sync with *.json manifests.
-    exports.version = '4001.0001.0000-dev-harmony-fb';
+    exports.version = '4001.0002.0000-dev-harmony-fb';
 
     exports.tokenize = tokenize;
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "esparse": "./bin/esparse.js",
         "esvalidate": "./bin/esvalidate.js"
     },
-    "version": "4001.0001.0000-dev-harmony-fb",
+    "version": "4001.0002.0000-dev-harmony-fb",
     "files": [
         "bin",
         "test/run.js",

--- a/test/fbtest.js
+++ b/test/fbtest.js
@@ -2043,6 +2043,152 @@ var fbTestFixture = {
             }
         },
 
+        '<a>    </a>': {
+            type: 'Program',
+            body: [{
+                type: 'ExpressionStatement',
+                expression: {
+                    type: 'XJSElement',
+                    openingElement: {
+                        type: 'XJSOpeningElement',
+                        name: {
+                            type: 'XJSIdentifier',
+                            name: 'a',
+                            range: [1, 2],
+                            loc: {
+                                start: {line: 1, column: 1},
+                                end: {line: 1, column: 2}
+                            }
+                        },
+                        selfClosing: false,
+                        attributes: [],
+                        range: [0, 3],
+                        loc: {
+                            start: {line: 1, column: 0},
+                            end: {line: 1, column: 3}
+                        }
+                    },
+                    closingElement: {
+                        type: 'XJSClosingElement',
+                        name: {
+                            type: 'XJSIdentifier',
+                            name: 'a',
+                            range: [9, 10],
+                            loc: {
+                                start: {line: 1, column: 9},
+                                end: {line: 1, column: 10}
+                            }
+                        },
+                        range: [7, 11],
+                        loc: {
+                            start: {line: 1, column: 7},
+                            end: {line: 1, column: 11}
+                        }
+                    },
+                    children: [
+                        {
+                            type: 'Literal',
+                            value: '    ',
+                            raw: '    ',
+                            range: [3, 7],
+                            loc: {
+                                start: {line: 1, column: 3},
+                                end: {line: 1, column: 7}
+                            }
+                        }
+                    ],
+                    range: [0, 11],
+                    loc: {
+                        start: {line: 1, column: 0},
+                        end: {line: 1, column: 11}
+                    }
+                },
+                range: [0, 11],
+                loc: {
+                    start: {line: 1, column: 0},
+                    end: {line: 1, column: 11}
+                }
+            }],
+            range: [0, 11],
+            loc: {
+                start: {line: 1, column: 0},
+                end: {line: 1, column: 11}
+            },
+            tokens: [
+                {
+                    type: 'Punctuator',
+                    value: '<',
+                    range: [0, 1],
+                    loc: {
+                        start: {line: 1, column: 0},
+                        end: {line: 1, column: 1}
+                    }
+                },
+                {
+                    type: 'XJSIdentifier',
+                    value: 'a',
+                    range: [1, 2],
+                    loc: {
+                        start: {line: 1, column: 1},
+                        end: {line: 1, column: 2}
+                    }
+                },
+                {
+                    type: 'Punctuator',
+                    value: '>',
+                    range: [2, 3],
+                    loc: {
+                        start: {line: 1, column: 2},
+                        end: {line: 1, column: 3}
+                    }
+                },
+                {
+                    type: 'XJSText',
+                    value: '    ',
+                    range: [3, 7],
+                    loc: {
+                        start: {line: 1, column: 3},
+                        end: {line: 1, column: 7}
+                    }
+                },
+                {
+                    type: 'Punctuator',
+                    value: '<',
+                    range: [7, 8],
+                    loc: {
+                        start: {line: 1, column: 7},
+                        end: {line: 1, column: 8}
+                    }
+                },
+                {
+                    type: 'Punctuator',
+                    value: '/',
+                    range: [8, 9],
+                    loc: {
+                        start: {line: 1, column: 8},
+                        end: {line: 1, column: 9}
+                    }
+                },
+                {
+                    type: 'XJSIdentifier',
+                    value: 'a',
+                    range: [9, 10],
+                    loc: {
+                        start: {line: 1, column: 9},
+                        end: {line: 1, column: 10}
+                    }
+                },
+                {
+                    type: 'Punctuator',
+                    value: '>',
+                    range: [10, 11],
+                    loc: {
+                        start: {line: 1, column: 10},
+                        end: {line: 1, column: 11}
+                    }
+                }
+            ]
+        }
     },
 
     'Invalid XJS Syntax': {

--- a/test/index.html
+++ b/test/index.html
@@ -105,6 +105,7 @@
 <script src="../esprima.js"></script>
 <script src="../assets/json2.js"></script>
 <script src="test.js"></script>
+<script src="fbtest.js"></script>
 <script src="harmonytest.js"></script>
 <script src="runner.js"></script>
 <script>


### PR DESCRIPTION
With `tokens` option enabled, esprima-fb returns incorrect array of tokens in `ast.tokens` property in following ways:
1. Duplicate `XJSText` tokens appear due to double-peeking next token into tokens array by both `expect()` in `parseXJSOpeningElement()` and `peek()` in `parseXJSElement()`.
2. Whitespaces in `<Tag> a </Tag>` were ignored and returned as pure `'a'` literal inside of `XJSText` element; this also caused children array of `<Tag> </Tag>` to be empty when `tokens` option was enabled.

Both bugs are fixed and regression test added.

Also:
1. Ignored `node_modules` folder.
2. Added running JSX tests in browser.
3. Changed versions in code to same as in package.json (required for tests).
