### PR TITLE
`\r\n` in JSX text should be considered as single line separator

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -5648,6 +5648,11 @@ parseYieldExpression: true
                 str += scanXJSEntity();
             } else {
                 index++;
+                if (ch === '\r' && source[index] === '\n') {
+                    str += ch;
+                    ch = source[index];
+                    index++;
+                }
                 if (isLineTerminator(ch.charCodeAt(0))) {
                     ++lineNumber;
                     lineStart = index;

--- a/esprima.js
+++ b/esprima.js
@@ -5647,13 +5647,13 @@ parseYieldExpression: true
             if (ch === '&') {
                 str += scanXJSEntity();
             } else {
-                index++;
-                if (ch === '\r' && source[index] === '\n') {
-                    str += ch;
-                    ch = source[index];
-                    index++;
-                }
+                ++index;
                 if (isLineTerminator(ch.charCodeAt(0))) {
+                    if (ch === '\r' && source[index] === '\n') {
+                        str += ch;
+                        ch = source[index];
+                        index++;
+                    }
                     ++lineNumber;
                     lineStart = index;
                 }

--- a/test/fbtest.js
+++ b/test/fbtest.js
@@ -631,7 +631,7 @@ var fbTestFixture = {
             }
         },
 
-        '<AbC-def\n  test="&#x0026;&#38;">\nbar\nbaz\n</AbC-def>': {
+        '<AbC-def\n  test="&#x0026;&#38;">\nbar\nbaz\r\n</AbC-def>': {
             type: "ExpressionStatement",
             expression: {
                 type: "XJSElement",
@@ -733,8 +733,8 @@ var fbTestFixture = {
                         type: "XJSIdentifier",
                         name: "AbC-def",
                         range: [
-                            43,
-                            50
+                            44,
+                            51
                         ],
                         loc: {
                             start: {
@@ -748,8 +748,8 @@ var fbTestFixture = {
                         }
                     },
                     range: [
-                        41,
-                        51
+                        42,
+                        52
                     ],
                     loc: {
                         start: {
@@ -765,11 +765,11 @@ var fbTestFixture = {
                 children: [
                     {
                         type: "Literal",
-                        value: "\nbar\nbaz\n",
-                        raw: "\nbar\nbaz\n",
+                        value: "\nbar\nbaz\r\n",
+                        raw: "\nbar\nbaz\r\n",
                         range: [
                             32,
-                            41
+                            42
                         ],
                         loc: {
                             start: {
@@ -785,7 +785,7 @@ var fbTestFixture = {
                 ],
                 range: [
                     0,
-                    51
+                    52
                 ],
                 loc: {
                     start: {
@@ -800,7 +800,7 @@ var fbTestFixture = {
             },
             range: [
                 0,
-                51
+                52
             ],
             loc: {
                 start: {


### PR DESCRIPTION
Currently `\r\n` in JSX content is treated as separate line separators, and that results in incorrect line numbers in location properties, and possibility of having broken source maps.

This fix forces them to be treated as single line separator.
