### PR TITLE
Regexp tokens are out of order (this shows the error not the fix)

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -5142,7 +5142,7 @@ var testFixture = {
             }]
         },
 
-        'var x = /[x-z]/i': {
+        'var x = { xfoo: /[x-z]/i }': {
             type: 'Program',
             body: [{
                 type: 'VariableDeclaration',


### PR DESCRIPTION
This is not present in upstream esprima (looks like this was forked from the harmony branch which has some ... uh issues).

Digging through some code I suspect this is the fix: https://github.com/ariya/esprima/commit/32ba2a27e65e8e7b6dd50cb843206ff00693c222

As it stands if your relying on the token ordering your going to have a bad time with regexp inside of an object (maybe other things as well)
