### PR TITLE
Small XJS Ast changes to match ast-types

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1829,7 +1829,7 @@ parseYieldExpression: true
             return {
                 type: Syntax.XJSAttribute,
                 name: name,
-                value: value
+                value: value || null
             };
         },
 
@@ -5901,7 +5901,7 @@ parseYieldExpression: true
     }
 
     function parseXJSElement() {
-        var openingElement, closingElement, children = [], origInXJSChild, origInXJSTag, marker = markerCreate();
+        var openingElement, closingElement = null, children = [], origInXJSChild, origInXJSTag, marker = markerCreate();
 
         origInXJSChild = state.inXJSChild;
         origInXJSTag = state.inXJSTag;

--- a/test/fbtest.js
+++ b/test/fbtest.js
@@ -25,6 +25,7 @@ var fbTestFixture = {
                       end: { line: 1, column: 5 }
                   }
                 },
+                closingElement: null,
                 children: [],
                 range: [0, 5],
                 loc: {
@@ -99,6 +100,7 @@ var fbTestFixture = {
                                 end: { line: 1, column: 8 }
                             }
                         },
+                        value: null,
                         range: [5, 8],
                         loc: {
                             start: { line: 1, column: 5 },
@@ -111,6 +113,7 @@ var fbTestFixture = {
                         end: { line: 1, column: 11 }
                     }
                 },
+                closingElement: null,
                 children: [],
                 range: [0, 11],
                 loc: {
@@ -300,6 +303,7 @@ var fbTestFixture = {
                                 end: { line: 1, column: 32 }
                             }
                         },
+                        closingElement: null,
                         children: [],
                         range: [27, 32],
                         loc: {
@@ -438,6 +442,7 @@ var fbTestFixture = {
                         end: { line: 1, column: 29 }
                     }
                 },
+                closingElement: null,
                 children: [],
                 range: [0, 29],
                 loc: {
@@ -492,6 +497,7 @@ var fbTestFixture = {
                         }
                     }
                 },
+                closingElement: null,
                 children: [],
                 range: [
                     0,
@@ -921,6 +927,7 @@ var fbTestFixture = {
                                                 }
                                             }
                                         },
+                                        closingElement: null,
                                         children: [],
                                         range: [
                                             10,
@@ -976,6 +983,7 @@ var fbTestFixture = {
                                                 }
                                             }
                                         },
+                                        closingElement: null,
                                         children: [],
                                         range: [
                                             18,
@@ -1053,6 +1061,7 @@ var fbTestFixture = {
                         }
                     }
                 },
+                closingElement: null,
                 children: [],
                 range: [
                     0,
@@ -1401,6 +1410,7 @@ var fbTestFixture = {
                             }
                         }
                     },
+                    closingElement: null,
                     children: [],
                     range: [
                         5,
@@ -1551,6 +1561,7 @@ var fbTestFixture = {
                                         }
                                     }
                                 },
+                                closingElement: null,
                                 "children": [],
                                 "range": [
                                     16,
@@ -1743,6 +1754,7 @@ var fbTestFixture = {
                         }
                     }
                 },
+                closingElement: null,
                 "children": [],
                 "range": [
                     0,
@@ -2014,6 +2026,7 @@ var fbTestFixture = {
                             end: { line: 1, column: 8 }
                         }
                     },
+                    closingElement: null,
                     children: [],
                     range: [1, 8],
                     loc: {
@@ -2120,6 +2133,7 @@ var fbTestFixture = {
                         }
                     }
                 },
+                closingElement: null,
                 "children": [],
                 "range": [
                     0,
@@ -2283,6 +2297,7 @@ var fbTestFixture = {
                         }
                     }
                 },
+                closingElement: null,
                 "children": [],
                 "range": [
                     0,


### PR DESCRIPTION
Summary:
I found two cases where we are using `undefined` instead of `null`.
This doesn't match the general idea that `null` indiciates a missing node and
also doesn't match the ast-types spec here:
https://github.com/benjamn/ast-types/blob/master/def/fb-harmony.js

Test Plan:
node test/run.js
Made sure all fb js still parses
Ran jest tests
