### PR TITLE
Scan > and < only as single char punctuators in XJSTag/Child

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -724,6 +724,23 @@ parseYieldExpression: true, parseAwaitExpression: true
             ch3,
             ch4;
 
+        if (state.inXJSTag || state.inXJSChild) {
+            // Don't need to check for '{' and '}' as it's already handled
+            // correctly by default.
+            switch (code) {
+            case 60:  // <
+            case 62:  // >
+                ++index;
+                return {
+                    type: Token.Punctuator,
+                    value: String.fromCharCode(code),
+                    lineNumber: lineNumber,
+                    lineStart: lineStart,
+                    range: [start, index]
+                };
+            }
+        }
+
         switch (code) {
         // Check for most common single-character punctuators.
         case 40:   // ( open bracket

--- a/test/fbtest.js
+++ b/test/fbtest.js
@@ -48,6 +48,7 @@ module.exports = {
         '<div pre="leading" pre2="attribute" {...props}></div>',
         '<a>    </a>',
         '<a .../*hai*/asdf/>',
+        '<a>= == =</a>',
     ],
     'Invalid XJS Syntax': [
         '</>',

--- a/test/fbtest.rec.js
+++ b/test/fbtest.rec.js
@@ -4,7 +4,7 @@
 * tests/fbtest.js and run tools/generate-fbtest.js
 */
 
-var numTests = 198
+var numTests = 199
 var testFixture;
 
 var fbTestFixture = {
@@ -1965,6 +1965,68 @@ var fbTestFixture = {
             message: 'Error: Line 1: Unexpected token ...',
             description: 'Unexpected token ...'
 
+        },
+        '<a>= == =</a>': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'XJSElement',
+                openingElement: {
+                    type: 'XJSOpeningElement',
+                    name: {
+                        type: 'XJSIdentifier',
+                        name: 'a',
+                        range: [1, 2],
+                        loc: {
+                            start: { line: 1, column: 1 },
+                            end: { line: 1, column: 2 }
+                        }
+                    },
+                    selfClosing: false,
+                    attributes: [],
+                    range: [0, 3],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 3 }
+                    }
+                },
+                closingElement: {
+                    type: 'XJSClosingElement',
+                    name: {
+                        type: 'XJSIdentifier',
+                        name: 'a',
+                        range: [11, 12],
+                        loc: {
+                            start: { line: 1, column: 11 },
+                            end: { line: 1, column: 12 }
+                        }
+                    },
+                    range: [9, 13],
+                    loc: {
+                        start: { line: 1, column: 9 },
+                        end: { line: 1, column: 13 }
+                    }
+                },
+                children: [{
+                    type: 'Literal',
+                    value: '= == =',
+                    raw: '= == =',
+                    range: [3, 9],
+                    loc: {
+                        start: { line: 1, column: 3 },
+                        end: { line: 1, column: 9 }
+                    }
+                }],
+                range: [0, 13],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 13 }
+                }
+            },
+            range: [0, 13],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 13 }
+            }
         },
     },
     'Invalid XJS Syntax': {


### PR DESCRIPTION
Avoid extended scanning of `>` and `<` inside XJS to prevent occurences of `>=`, `>>`, etc from being parsed as the JavaScript operators rather than `>` followed by `=`. Fixes #37.

Test plan: `npm test`

cc @jeffmo @benjamn
