### PR TITLE
Fix duplicate property error for property name literals in class definitions

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -5120,7 +5120,7 @@ parseYieldExpression: true, parseAwaitExpression: true
     function parseMethodDefinition(existingPropNames) {
         var token, key, param, propType, isValidDuplicateProp = false,
             isAsync, marker = markerCreate(), token2, parametricType,
-            parametricTypeMarker, annotationMarker;
+            parametricTypeMarker, annotationMarker, methodName;
 
         if (lookahead.value === 'static') {
             propType = ClassPropertyType.static;
@@ -5145,24 +5145,25 @@ parseYieldExpression: true, parseAwaitExpression: true
 
         if (token.value === 'get' && !match('(')) {
             key = parseObjectPropertyKey();
+            methodName = key.type === Syntax.Literal ? key.value : key.name;
 
             // It is a syntax error if any other properties have a name
             // duplicating this one unless they are a setter
-            if (existingPropNames[propType].hasOwnProperty(key.name)) {
+            if (existingPropNames[propType].hasOwnProperty(methodName)) {
                 isValidDuplicateProp =
                     // There isn't already a getter for this prop
-                    existingPropNames[propType][key.name].get === undefined
+                    existingPropNames[propType][methodName].get === undefined
                     // There isn't already a data prop by this name
-                    && existingPropNames[propType][key.name].data === undefined
+                    && existingPropNames[propType][methodName].data === undefined
                     // The only existing prop by this name is a setter
-                    && existingPropNames[propType][key.name].set !== undefined;
+                    && existingPropNames[propType][methodName].set !== undefined;
                 if (!isValidDuplicateProp) {
                     throwError(key, Messages.IllegalDuplicateClassProperty);
                 }
             } else {
-                existingPropNames[propType][key.name] = {};
+                existingPropNames[propType][methodName] = {};
             }
-            existingPropNames[propType][key.name].get = true;
+            existingPropNames[propType][methodName].get = true;
 
             expect('(');
             expect(')');
@@ -5175,24 +5176,25 @@ parseYieldExpression: true, parseAwaitExpression: true
         }
         if (token.value === 'set' && !match('(')) {
             key = parseObjectPropertyKey();
+            methodName = key.type === Syntax.Literal ? key.value : key.name;
 
             // It is a syntax error if any other properties have a name
             // duplicating this one unless they are a getter
-            if (existingPropNames[propType].hasOwnProperty(key.name)) {
+            if (existingPropNames[propType].hasOwnProperty(methodName)) {
                 isValidDuplicateProp =
                     // There isn't already a setter for this prop
-                    existingPropNames[propType][key.name].set === undefined
+                    existingPropNames[propType][methodName].set === undefined
                     // There isn't already a data prop by this name
-                    && existingPropNames[propType][key.name].data === undefined
+                    && existingPropNames[propType][methodName].data === undefined
                     // The only existing prop by this name is a getter
-                    && existingPropNames[propType][key.name].get !== undefined;
+                    && existingPropNames[propType][methodName].get !== undefined;
                 if (!isValidDuplicateProp) {
                     throwError(key, Messages.IllegalDuplicateClassProperty);
                 }
             } else {
-                existingPropNames[propType][key.name] = {};
+                existingPropNames[propType][methodName] = {};
             }
-            existingPropNames[propType][key.name].set = true;
+            existingPropNames[propType][methodName].set = true;
 
             expect('(');
             token = lookahead;
@@ -5217,12 +5219,13 @@ parseYieldExpression: true, parseAwaitExpression: true
 
         // It is a syntax error if any other properties have the same name as a
         // non-getter, non-setter method
-        if (existingPropNames[propType].hasOwnProperty(key.name)) {
+        methodName = key.type === Syntax.Literal ? key.value : key.name;
+        if (existingPropNames[propType].hasOwnProperty(methodName)) {
             throwError(key, Messages.IllegalDuplicateClassProperty);
         } else {
-            existingPropNames[propType][key.name] = {};
+            existingPropNames[propType][methodName] = {};
         }
-        existingPropNames[propType][key.name].data = true;
+        existingPropNames[propType][methodName].data = true;
 
         return markerApply(marker, delegate.createMethodDefinition(
             propType,

--- a/test/harmonytest.js
+++ b/test/harmonytest.js
@@ -10799,6 +10799,118 @@ var harmonyTestFixture = {
             }
         },
 
+        'class A { 42() {} "foo"() {}}': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Literal',
+                        value: 42,
+                        raw: '42',
+                        range: [10, 12],
+                        loc: {
+                            start: { line: 1, column: 10 },
+                            end: { line: 1, column: 12 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [15, 17],
+                            loc: {
+                                start: { line: 1, column: 15 },
+                                end: { line: 1, column: 17 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [15, 17],
+                        loc: {
+                            start: { line: 1, column: 15 },
+                            end: { line: 1, column: 17 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    range: [10, 17],
+                    loc: {
+                        start: { line: 1, column: 10 },
+                        end: { line: 1, column: 17 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Literal',
+                        value: 'foo',
+                        raw: '"foo"',
+                        range: [18, 23],
+                        loc: {
+                            start: { line: 1, column: 18 },
+                            end: { line: 1, column: 23 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [26, 28],
+                            loc: {
+                                start: { line: 1, column: 26 },
+                                end: { line: 1, column: 28 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [26, 28],
+                        loc: {
+                            start: { line: 1, column: 26 },
+                            end: { line: 1, column: 28 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    range: [18, 28],
+                    loc: {
+                        start: { line: 1, column: 18 },
+                        end: { line: 1, column: 28 }
+                    }
+                }],
+                range: [8, 29],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 29 }
+                }
+            },
+            range: [0, 29],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 29 }
+            }
+        },
+
         'class A { get foo() {} get foo() {} }': {
             index: 30,
             lineNumber: 1,
@@ -10843,6 +10955,14 @@ var harmonyTestFixture = {
             index: 26,
             lineNumber: 1,
             column: 27,
+            message: 'Error: Line 1: Illegal duplicate property in class definition',
+            description: 'Illegal duplicate property in class definition'
+        },
+
+        'class A { foo() {} "foo"() {} }': {
+            index: 24,
+            lineNumber: 1,
+            column: 25,
             message: 'Error: Line 1: Illegal duplicate property in class definition',
             description: 'Illegal duplicate property in class definition'
         },


### PR DESCRIPTION
Duplicate method definition detection doesn't treat string and number literal property names correctly. The following code raises a "Illegal duplicate property in class definition" error: 

```
class A { 42() {} "foo"() {} }
```

This happens because we used `key.name` to get the "name" of the property name, but `.name` only exists for IdentifierName, not for StringLiteral or NumericLiteral.

This changes the code to use either `.name` or `.value` depending on the type of property name.

It also fixes another problem: `class A { foo() {} "foo"() {}}` should have thrown a duplicate property error, but it didn't.
