### PR TITLE
Let bin scripts use the correct npm module for esprima.

### DIFF
--- a/bin/esparse.js
+++ b/bin/esparse.js
@@ -30,7 +30,7 @@ var fs, esprima, fname, content, options, syntax;
 
 if (typeof require === 'function') {
     fs = require('fs');
-    esprima = require('esprima');
+    esprima = require('esprima-fb');
 } else if (typeof load === 'function') {
     try {
         load('esprima.js');

--- a/bin/esvalidate.js
+++ b/bin/esvalidate.js
@@ -36,7 +36,7 @@ if (typeof esprima === 'undefined') {
         esprima = require('./esprima');
     } else if (typeof require === 'function') {
         fs = require('fs');
-        esprima = require('esprima');
+        esprima = require('esprima-fb');
     } else if (typeof load === 'function') {
         try {
             load('esprima.js');


### PR DESCRIPTION
The scripts included with esprima in `bin` were importing the upstream esprima module, which goes by a different name in npm. This caused anybody using esprima from the command-line to confusingly lack JSX support.
