### PR TITLE
Parsing Type Alias

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -5553,7 +5553,7 @@ parseYieldExpression: true, parseAwaitExpression: true
             }
         }
 
-        if (lookahead.value === 'type'
+        if (matchContextualKeyword('type')
                 && lookahead2().type === Token.Identifier) {
             return parseTypeAlias();
         }
@@ -6446,10 +6446,7 @@ parseYieldExpression: true, parseAwaitExpression: true
 
     function parseTypeAlias() {
         var left, marker = markerCreate(), right;
-        if (lookahead.value !== 'type') {
-            throwUnexpected(lookahead);
-        }
-        lex();
+        expectContextualKeyword('type');
         left = parseTypeAnnotationWithoutUnions();
         expect('=');
         right = parseTypeAnnotation(true);

--- a/esprima.js
+++ b/esprima.js
@@ -4904,11 +4904,6 @@ parseYieldExpression: true, parseAwaitExpression: true
             }
         }
 
-        if (lookahead.value === 'type'
-                && lookahead2().type === Token.Identifier) {
-            return parseTypeAlias();
-        }
-
         if (matchAsyncFuncExprOrDecl()) {
             return parseFunctionDeclaration();
         }
@@ -5556,6 +5551,11 @@ parseYieldExpression: true, parseAwaitExpression: true
             default:
                 return parseStatement();
             }
+        }
+
+        if (lookahead.value === 'type'
+                && lookahead2().type === Token.Identifier) {
+            return parseTypeAlias();
         }
 
         if (lookahead.type !== Token.EOF) {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "lint": "node tools/check-version.js && node node_modules/eslint/bin/eslint.js esprima.js && node node_modules/jslint/bin/jslint.js esprima.js",
         "coverage": "npm run-script analyze-coverage && npm run-script check-coverage",
         "analyze-coverage": "node node_modules/istanbul/lib/cli.js cover test/runner.js",
-        "check-coverage": "node node_modules/istanbul/lib/cli.js check-coverage --statement -11 --branch -28 --function 99.69",
+        "check-coverage": "node node_modules/istanbul/lib/cli.js check-coverage --statement -12 --branch -29 --function 99.69",
         "complexity": "npm run-script analyze-complexity && npm run-script check-complexity",
         "analyze-complexity": "node tools/list-complexity.js",
         "check-complexity": "node node_modules/complexity-report/src/cli.js --maxcc 31 --silent -l -w esprima.js",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "lint": "node tools/check-version.js && node node_modules/eslint/bin/eslint.js esprima.js && node node_modules/jslint/bin/jslint.js esprima.js",
         "coverage": "npm run-script analyze-coverage && npm run-script check-coverage",
         "analyze-coverage": "node node_modules/istanbul/lib/cli.js cover test/runner.js",
-        "check-coverage": "node node_modules/istanbul/lib/cli.js check-coverage --statement -12 --branch -29 --function 99.69",
+        "check-coverage": "node node_modules/istanbul/lib/cli.js check-coverage --statement -11 --branch -28 --function 99.69",
         "complexity": "npm run-script analyze-complexity && npm run-script check-complexity",
         "analyze-complexity": "node tools/list-complexity.js",
         "check-complexity": "node node_modules/complexity-report/src/cli.js --maxcc 31 --silent -l -w esprima.js",

--- a/test/fbtest.js
+++ b/test/fbtest.js
@@ -7128,7 +7128,16 @@ var fbTestFixture = {
             start: { line: 1, column: 0 },
             end: { line: 1, column: 20 }
         }
-      }
+      },
+   },
+   'Invalid Type Alias': {
+    'if (true) type foo = number': {
+      index: 15,
+      lineNumber: 1,
+      column: 16,
+      message: 'Error: Line 1: Unexpected identifier',
+      description: 'Unexpected identifier'
+    }
    }
 };
 

--- a/test/fbtest.js
+++ b/test/fbtest.js
@@ -6997,7 +6997,139 @@ var fbTestFixture = {
             message: 'Error: Line 1: Unexpected identifier',
             description: 'Unexpected identifier'
         }
-    }
+    },
+    'Type Alias': {
+      'type FBID = number;': {
+        type: 'TypeAlias',
+        left: {
+            type: 'TypeAnnotation',
+            id: {
+                type: 'Identifier',
+                name: 'FBID',
+                range: [5, 9],
+                loc: {
+                    start: { line: 1, column: 5 },
+                    end: { line: 1, column: 9 }
+                }
+            },
+            params: null,
+            returnType: null,
+            nullable: false,
+            range: [5, 9],
+            loc: {
+                start: { line: 1, column: 5 },
+                end: { line: 1, column: 9 }
+            }
+        },
+        right: {
+            type: 'TypeAnnotation',
+            id: {
+                type: 'Identifier',
+                name: 'number',
+                range: [12, 18],
+                loc: {
+                    start: { line: 1, column: 12 },
+                    end: { line: 1, column: 18 }
+                }
+            },
+            params: null,
+            returnType: null,
+            nullable: false,
+            range: [12, 18],
+            loc: {
+                start: { line: 1, column: 12 },
+                end: { line: 1, column: 18 }
+            }
+        },
+        range: [0, 19],
+        loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 19 }
+        }
+      },
+      'type Foo<T> = Bar<T>': {
+        type: 'TypeAlias',
+        left: {
+            type: 'TypeAnnotation',
+            id: {
+                type: 'Identifier',
+                name: 'Foo',
+                range: [5, 8],
+                loc: {
+                    start: { line: 1, column: 5 },
+                    end: { line: 1, column: 8 }
+                }
+            },
+            parametricType: {
+                type: 'ParametricTypeAnnotation',
+                params: [{
+                    type: 'Identifier',
+                    name: 'T',
+                    range: [9, 10],
+                    loc: {
+                        start: { line: 1, column: 9 },
+                        end: { line: 1, column: 10 }
+                    }
+                }],
+                range: [8, 11],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 11 }
+                }
+            },
+            params: null,
+            returnType: null,
+            nullable: false,
+            range: [5, 11],
+            loc: {
+                start: { line: 1, column: 5 },
+                end: { line: 1, column: 11 }
+            }
+        },
+        right: {
+            type: 'TypeAnnotation',
+            id: {
+                type: 'Identifier',
+                name: 'Bar',
+                range: [14, 17],
+                loc: {
+                    start: { line: 1, column: 14 },
+                    end: { line: 1, column: 17 }
+                }
+            },
+            parametricType: {
+                type: 'ParametricTypeAnnotation',
+                params: [{
+                    type: 'Identifier',
+                    name: 'T',
+                    range: [18, 19],
+                    loc: {
+                        start: { line: 1, column: 18 },
+                        end: { line: 1, column: 19 }
+                    }
+                }],
+                range: [17, 20],
+                loc: {
+                    start: { line: 1, column: 17 },
+                    end: { line: 1, column: 20 }
+                }
+            },
+            params: null,
+            returnType: null,
+            nullable: false,
+            range: [14, 20],
+            loc: {
+                start: { line: 1, column: 14 },
+                end: { line: 1, column: 20 }
+            }
+        },
+        range: [0, 20],
+        loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 20 }
+        }
+      }
+   }
 };
 
 // Merge fbTestFixture in to testFixture

--- a/test/test.js
+++ b/test/test.js
@@ -10096,6 +10096,43 @@ var testFixture = {
             }
         },
 
+        'type = 42': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'AssignmentExpression',
+                operator: '=',
+                left: {
+                    type: 'Identifier',
+                    name: 'type',
+                    range: [0, 4],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 4 }
+                    }
+                },
+                right: {
+                    type: 'Literal',
+                    value: 42,
+                    raw: '42',
+                    range: [7, 9],
+                    loc: {
+                        start: { line: 1, column: 7 },
+                        end: { line: 1, column: 9 }
+                    }
+                },
+                range: [0, 9],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 9 }
+                }
+            },
+            range: [0, 9],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 9 }
+            }
+        },
+
         'x *= 42': {
             type: 'ExpressionStatement',
             expression: {

--- a/test/test.js
+++ b/test/test.js
@@ -20014,6 +20014,7 @@ var testFixture = {
                 ThisExpression: 'ThisExpression',
                 ThrowStatement: 'ThrowStatement',
                 TryStatement: 'TryStatement',
+                TypeAlias: 'TypeAlias',
                 TypeAnnotatedIdentifier: 'TypeAnnotatedIdentifier',
                 TypeAnnotation: 'TypeAnnotation',
                 TypeofTypeAnnotation: 'TypeofTypeAnnotation',


### PR DESCRIPTION
This adds the ability to parse type alias declarations. They look like

```
type bar = number;
type Foo<T> = Bar<T>;
```
