### PR TITLE
Parse interfaces

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -38,7 +38,7 @@ parseClassExpression: true, parseClassDeclaration: true, parseExpression: true,
 parseForStatement: true,
 parseFunctionDeclaration: true, parseFunctionExpression: true,
 parseFunctionSourceElements: true, parseVariableIdentifier: true,
-parseImportSpecifier: true,
+parseImportSpecifier: true, parseInterface: true,
 parseLeftHandSideExpression: true, parseParams: true, validateParam: true,
 parseSpreadOrAssignmentExpression: true,
 parseStatement: true, parseSourceElement: true, parseConciseBody: true,
@@ -162,6 +162,7 @@ parseYieldExpression: true, parseAwaitExpression: true
         ImportDefaultSpecifier: 'ImportDefaultSpecifier',
         ImportNamespaceSpecifier: 'ImportNamespaceSpecifier',
         ImportSpecifier: 'ImportSpecifier',
+        InterfaceDeclaration: 'InterfaceDeclaration',
         LabeledStatement: 'LabeledStatement',
         Literal: 'Literal',
         LogicalExpression: 'LogicalExpression',
@@ -1943,6 +1944,15 @@ parseYieldExpression: true, parseAwaitExpression: true
                 type: Syntax.TypeAlias,
                 left: left,
                 right: right
+            };
+        },
+
+        createInterface: function (id, body, extended) {
+            return {
+                type: Syntax.InterfaceDeclaration,
+                id: id,
+                body: body,
+                extends: extended
             };
         },
 
@@ -3916,6 +3926,25 @@ parseYieldExpression: true, parseAwaitExpression: true
         ));
     }
 
+    function parseGenericTypeAnnotation(nullable) {
+        var marker = markerCreate(), params = null, parametricType, returnType = null,
+            typeIdentifier;
+
+        nullable = nullable || false;
+
+        typeIdentifier = parseVariableIdentifier();
+        if (match('<')) {
+            parametricType = parseParametricTypeAnnotation();
+        }
+        return markerApply(marker, delegate.createTypeAnnotation(
+            typeIdentifier,
+            parametricType,
+            params,
+            returnType,
+            nullable
+        ));
+    }
+
     function parseTypeAnnotationWithoutUnions() {
         var typeIdentifier = null, params = null, returnType = null,
             nullable = false, marker = markerCreate(), returnTypeMarker = null,
@@ -3931,11 +3960,10 @@ parseYieldExpression: true, parseAwaitExpression: true
         }
 
         if (lookahead.type === Token.Identifier) {
-            typeIdentifier = parseVariableIdentifier();
-            if (match('<')) {
-                parametricType = parseParametricTypeAnnotation();
-            }
-        } else if (match('(')) {
+            return markerApply(marker, parseGenericTypeAnnotation(nullable));
+        }
+
+        if (match('(')) {
             lex();
             params = [];
             while (lookahead.type === Token.Identifier || match('?')) {
@@ -3953,23 +3981,25 @@ parseYieldExpression: true, parseAwaitExpression: true
             expect('=>');
 
             returnType = parseTypeAnnotation(true);
-        } else {
-            if (matchKeyword('void')) {
-                return markerApply(marker, parseVoidTypeAnnotation());
-            }
-            if (matchKeyword('typeof')) {
-                return markerApply(marker, parseTypeofTypeAnnotation());
-            }
-            throwUnexpected(lookahead);
+
+            return markerApply(marker, delegate.createTypeAnnotation(
+                typeIdentifier,
+                parametricType,
+                params,
+                returnType,
+                nullable
+            ));
         }
 
-        return markerApply(marker, delegate.createTypeAnnotation(
-            typeIdentifier,
-            parametricType,
-            params,
-            returnType,
-            nullable
-        ));
+        if (matchKeyword('void')) {
+            return markerApply(marker, parseVoidTypeAnnotation());
+        }
+
+        if (matchKeyword('typeof')) {
+            return markerApply(marker, parseTypeofTypeAnnotation());
+        }
+
+        throwUnexpected(lookahead);
     }
 
     function parseUnionTypeAnnotation(types) {
@@ -5558,6 +5588,11 @@ parseYieldExpression: true, parseAwaitExpression: true
             return parseTypeAlias();
         }
 
+        if (matchContextualKeyword('interface')
+                && lookahead2().type === Token.Identifier) {
+            return parseInterface();
+        }
+
         if (lookahead.type !== Token.EOF) {
             return parseStatement();
         }
@@ -6447,11 +6482,39 @@ parseYieldExpression: true, parseAwaitExpression: true
     function parseTypeAlias() {
         var left, marker = markerCreate(), right;
         expectContextualKeyword('type');
-        left = parseTypeAnnotationWithoutUnions();
+        left = parseGenericTypeAnnotation();
         expect('=');
         right = parseTypeAnnotation(true);
         consumeSemicolon();
         return markerApply(marker, delegate.createTypeAlias(left, right));
+    }
+
+    function parseInterface() {
+        var body, bodyMarker, extended = [], id, marker = markerCreate();
+
+        expectContextualKeyword('interface');
+        id = parseGenericTypeAnnotation();
+
+        if (matchKeyword('extends')) {
+            expectKeyword('extends');
+
+            while (index < length) {
+                extended.push(parseGenericTypeAnnotation());
+                if (!match(',')) {
+                    break;
+                }
+                expect(',');
+            }
+        }
+
+        bodyMarker = markerCreate();
+        body = markerApply(bodyMarker, parseObjectTypeAnnotation());
+
+        return markerApply(marker, delegate.createInterface(
+            id,
+            body,
+            extended
+        ));
     }
 
     function collectToken() {

--- a/esprima.js
+++ b/esprima.js
@@ -3909,7 +3909,7 @@ parseYieldExpression: true, parseAwaitExpression: true
         ));
     }
 
-    function parseParametricTypeAnnotation() {
+    function parseTypeParameters() {
         var marker = markerCreate(), typeIdentifier, paramTypes = [];
 
         expect('<');
@@ -3934,7 +3934,7 @@ parseYieldExpression: true, parseAwaitExpression: true
 
         typeIdentifier = parseVariableIdentifier();
         if (match('<')) {
-            parametricType = parseParametricTypeAnnotation();
+            parametricType = parseTypeParameters();
         }
         return markerApply(marker, delegate.createTypeAnnotation(
             typeIdentifier,
@@ -5181,7 +5181,7 @@ parseYieldExpression: true, parseAwaitExpression: true
         id = parseVariableIdentifier();
 
         if (match('<')) {
-            parametricType = parseParametricTypeAnnotation();
+            parametricType = parseTypeParameters();
         }
 
         if (strict) {
@@ -5280,7 +5280,7 @@ parseYieldExpression: true, parseAwaitExpression: true
             }
 
             if (match('<')) {
-                parametricType = parseParametricTypeAnnotation();
+                parametricType = parseTypeParameters();
             }
         }
 
@@ -5440,7 +5440,7 @@ parseYieldExpression: true, parseAwaitExpression: true
         }
 
         if (match('<')) {
-            parametricType = parseParametricTypeAnnotation();
+            parametricType = parseTypeParameters();
         }
 
         isAsync = token.value === 'async' && !match('(');
@@ -5531,7 +5531,7 @@ parseYieldExpression: true, parseAwaitExpression: true
         }
 
         if (match('<')) {
-            parametricType = parseParametricTypeAnnotation();
+            parametricType = parseTypeParameters();
         }
 
         if (matchKeyword('extends')) {
@@ -5554,7 +5554,7 @@ parseYieldExpression: true, parseAwaitExpression: true
         id = parseVariableIdentifier();
 
         if (match('<')) {
-            parametricType = parseParametricTypeAnnotation();
+            parametricType = parseTypeParameters();
         }
 
         if (matchKeyword('extends')) {

--- a/test/fbtest.js
+++ b/test/fbtest.js
@@ -7129,15 +7129,343 @@ var fbTestFixture = {
             end: { line: 1, column: 20 }
         }
       },
+    },
+    'Interfaces': {
+      'interface A {}': {
+        type: 'InterfaceDeclaration',
+        id: {
+            type: 'TypeAnnotation',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [10, 11],
+                loc: {
+                    start: { line: 1, column: 10 },
+                    end: { line: 1, column: 11 }
+                }
+            },
+            params: null,
+            returnType: null,
+            nullable: false,
+            range: [10, 11],
+            loc: {
+                start: { line: 1, column: 10 },
+                end: { line: 1, column: 11 }
+            }
+        },
+        body: {
+            type: 'ObjectTypeAnnotation',
+            properties: [],
+            range: [12, 14],
+            loc: {
+                start: { line: 1, column: 12 },
+                end: { line: 1, column: 14 }
+            }
+        },
+        'extends': [],
+        range: [0, 14],
+        loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 14 }
+        }
+      },
+      'interface A extends B {}': {
+        type: 'InterfaceDeclaration',
+        id: {
+            type: 'TypeAnnotation',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [10, 11],
+                loc: {
+                    start: { line: 1, column: 10 },
+                    end: { line: 1, column: 11 }
+                }
+            },
+            params: null,
+            returnType: null,
+            nullable: false,
+            range: [10, 11],
+            loc: {
+                start: { line: 1, column: 10 },
+                end: { line: 1, column: 11 }
+            }
+        },
+        body: {
+            type: 'ObjectTypeAnnotation',
+            properties: [],
+            range: [22, 24],
+            loc: {
+                start: { line: 1, column: 22 },
+                end: { line: 1, column: 24 }
+            }
+        },
+        'extends': [{
+            type: 'TypeAnnotation',
+            id: {
+                type: 'Identifier',
+                name: 'B',
+                range: [20, 21],
+                loc: {
+                    start: { line: 1, column: 20 },
+                    end: { line: 1, column: 21 }
+                }
+            },
+            params: null,
+            returnType: null,
+            nullable: false,
+            range: [20, 21],
+            loc: {
+                start: { line: 1, column: 20 },
+                end: { line: 1, column: 21 }
+            }
+        }],
+        range: [0, 24],
+        loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 24 }
+        }
+      },
+      'interface A<T> extends B<T>, C<T> {}': {
+        type: 'InterfaceDeclaration',
+        id: {
+            type: 'TypeAnnotation',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [10, 11],
+                loc: {
+                    start: { line: 1, column: 10 },
+                    end: { line: 1, column: 11 }
+                }
+            },
+            parametricType: {
+                type: 'ParametricTypeAnnotation',
+                params: [{
+                    type: 'Identifier',
+                    name: 'T',
+                    range: [12, 13],
+                    loc: {
+                        start: { line: 1, column: 12 },
+                        end: { line: 1, column: 13 }
+                    }
+                }],
+                range: [11, 14],
+                loc: {
+                    start: { line: 1, column: 11 },
+                    end: { line: 1, column: 14 }
+                }
+            },
+            params: null,
+            returnType: null,
+            nullable: false,
+            range: [10, 14],
+            loc: {
+                start: { line: 1, column: 10 },
+                end: { line: 1, column: 14 }
+            }
+        },
+        body: {
+            type: 'ObjectTypeAnnotation',
+            properties: [],
+            range: [34, 36],
+            loc: {
+                start: { line: 1, column: 34 },
+                end: { line: 1, column: 36 }
+            }
+        },
+        'extends': [{
+            type: 'TypeAnnotation',
+            id: {
+                type: 'Identifier',
+                name: 'B',
+                range: [23, 24],
+                loc: {
+                    start: { line: 1, column: 23 },
+                    end: { line: 1, column: 24 }
+                }
+            },
+            parametricType: {
+                type: 'ParametricTypeAnnotation',
+                params: [{
+                    type: 'Identifier',
+                    name: 'T',
+                    range: [25, 26],
+                    loc: {
+                        start: { line: 1, column: 25 },
+                        end: { line: 1, column: 26 }
+                    }
+                }],
+                range: [24, 27],
+                loc: {
+                    start: { line: 1, column: 24 },
+                    end: { line: 1, column: 27 }
+                }
+            },
+            params: null,
+            returnType: null,
+            nullable: false,
+            range: [23, 27],
+            loc: {
+                start: { line: 1, column: 23 },
+                end: { line: 1, column: 27 }
+            }
+        }, {
+            type: 'TypeAnnotation',
+            id: {
+                type: 'Identifier',
+                name: 'C',
+                range: [29, 30],
+                loc: {
+                    start: { line: 1, column: 29 },
+                    end: { line: 1, column: 30 }
+                }
+            },
+            parametricType: {
+                type: 'ParametricTypeAnnotation',
+                params: [{
+                    type: 'Identifier',
+                    name: 'T',
+                    range: [31, 32],
+                    loc: {
+                        start: { line: 1, column: 31 },
+                        end: { line: 1, column: 32 }
+                    }
+                }],
+                range: [30, 33],
+                loc: {
+                    start: { line: 1, column: 30 },
+                    end: { line: 1, column: 33 }
+                }
+            },
+            params: null,
+            returnType: null,
+            nullable: false,
+            range: [29, 33],
+            loc: {
+                start: { line: 1, column: 29 },
+                end: { line: 1, column: 33 }
+            }
+        }],
+        range: [0, 36],
+        loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 36 }
+        }
+      },
+      'interface A { foo: () => number; }': {
+        type: 'InterfaceDeclaration',
+        id: {
+            type: 'TypeAnnotation',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [10, 11],
+                loc: {
+                    start: { line: 1, column: 10 },
+                    end: { line: 1, column: 11 }
+                }
+            },
+            params: null,
+            returnType: null,
+            nullable: false,
+            range: [10, 11],
+            loc: {
+                start: { line: 1, column: 10 },
+                end: { line: 1, column: 11 }
+            }
+        },
+        body: {
+            type: 'ObjectTypeAnnotation',
+            properties: [{
+                type: 'Property',
+                key: {
+                    type: 'Identifier',
+                    name: 'foo',
+                    range: [14, 17],
+                    loc: {
+                        start: { line: 1, column: 14 },
+                        end: { line: 1, column: 17 }
+                    }
+                },
+                value: {
+                    type: 'TypeAnnotation',
+                    id: null,
+                    params: [],
+                    returnType: {
+                        type: 'TypeAnnotation',
+                        id: {
+                            type: 'Identifier',
+                            name: 'number',
+                            range: [25, 31],
+                            loc: {
+                                start: { line: 1, column: 25 },
+                                end: { line: 1, column: 31 }
+                            }
+                        },
+                        params: null,
+                        returnType: null,
+                        nullable: false,
+                        range: [25, 31],
+                        loc: {
+                            start: { line: 1, column: 25 },
+                            end: { line: 1, column: 31 }
+                        }
+                    },
+                    nullable: false,
+                    range: [17, 31],
+                    loc: {
+                        start: { line: 1, column: 17 },
+                        end: { line: 1, column: 31 }
+                    }
+                },
+                kind: 'init',
+                method: false,
+                shorthand: false,
+                range: [14, 31],
+                loc: {
+                    start: { line: 1, column: 14 },
+                    end: { line: 1, column: 31 }
+                }
+            }],
+            range: [12, 34],
+            loc: {
+                start: { line: 1, column: 12 },
+                end: { line: 1, column: 34 }
+            }
+        },
+        'extends': [],
+        range: [0, 34],
+        loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 34 }
+        }
+      }
+    },
+    'Invalid Type Alias': {
+      'if (true) type foo = number': {
+        index: 15,
+        lineNumber: 1,
+        column: 16,
+        message: 'Error: Line 1: Unexpected identifier',
+        description: 'Unexpected identifier'
+      }
    },
-   'Invalid Type Alias': {
-    'if (true) type foo = number': {
-      index: 15,
-      lineNumber: 1,
-      column: 16,
-      message: 'Error: Line 1: Unexpected identifier',
-      description: 'Unexpected identifier'
-    }
+   'Invalid Interfaces': {
+      'interface {}': {
+        index: 10,
+        lineNumber: 1,
+        column: 11,
+        message: 'Error: Line 1: Unexpected token {',
+        description: 'Unexpected token {'
+      },
+      'interface A extends {}': {
+        index: 20,
+        lineNumber: 1,
+        column: 21,
+        message: 'Error: Line 1: Unexpected token {',
+        description: 'Unexpected token {'
+      },
    }
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -20024,6 +20024,7 @@ var testFixture = {
                 ImportDefaultSpecifier: "ImportDefaultSpecifier",
                 ImportNamespaceSpecifier: "ImportNamespaceSpecifier",
                 ImportSpecifier: 'ImportSpecifier',
+                InterfaceDeclaration: 'InterfaceDeclaration',
                 LabeledStatement: 'LabeledStatement',
                 Literal: 'Literal',
                 LogicalExpression: 'LogicalExpression',


### PR DESCRIPTION
Interfaces are pretty simple to parse. They are basically named object types that can optionally extend 1 or more other interfaces.

I cleaned up `parseTypeAnnotationWithoutUnions()` a little bit too.

Tested via `npm test` and the esprima tester
