### PR TITLE
Allowing leading commas inside function parameters and expressions

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -4093,11 +4093,19 @@ parseYieldExpression: true, parseAwaitExpression: true
                 }
 
                 lex();
+
+                if (match(')')) {
+                    break;
+                }
+
                 expr = parseSpreadOrAssignmentExpression();
                 expressions.push(expr);
 
                 if (expr.type === Syntax.SpreadElement) {
                     spreadFound = true;
+                    if (match(',') && lookahead2().value === ')') {
+                        lex();
+                    }
                     if (!match(')')) {
                         throwError({}, Messages.ElementAfterSpreadElement);
                     }
@@ -5692,6 +5700,9 @@ parseYieldExpression: true, parseAwaitExpression: true
         }
 
         if (rest) {
+            if (match(',') && lookahead2().value === ')') {
+                lex();
+            }
             if (!match(')')) {
                 throwError({}, Messages.ParameterAfterRestParameter);
             }
@@ -5724,6 +5735,9 @@ parseYieldExpression: true, parseAwaitExpression: true
                     break;
                 }
                 expect(',');
+                if (match(')')) {
+                    break;
+                }
             }
         }
 

--- a/test/harmonytest.js
+++ b/test/harmonytest.js
@@ -1968,7 +1968,7 @@ var harmonyTestFixture = {
             }
         },
 
-        'foo((x, y) => {})': {
+        'foo((x, y ) => {})': {
             type: 'ExpressionStatement',
             expression: {
                 type: 'CallExpression',
@@ -2005,36 +2005,99 @@ var harmonyTestFixture = {
                     body: {
                         type: 'BlockStatement',
                         body: [],
-                        range: [14, 16],
+                        range: [15, 17],
                         loc: {
-                            start: { line: 1, column: 14 },
-                            end: { line: 1, column: 16 }
+                            start: { line: 1, column: 15 },
+                            end: { line: 1, column: 17 }
                         }
                     },
                     rest: null,
                     generator: false,
                     expression: false,
-                    range: [4, 16],
+                    range: [4, 17],
                     loc: {
                         start: { line: 1, column: 4 },
-                        end: { line: 1, column: 16 }
+                        end: { line: 1, column: 17 }
                     }
                 }],
-                range: [0, 17],
+                range: [0, 18],
                 loc: {
                     start: { line: 1, column: 0 },
-                    end: { line: 1, column: 17 }
+                    end: { line: 1, column: 18 }
                 }
             },
-            range: [0, 17],
+            range: [0, 18],
             loc: {
                 start: { line: 1, column: 0 },
-                end: { line: 1, column: 17 }
+                end: { line: 1, column: 18 }
+            }
+        },
+
+        'foo((x, y,) => {})': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'CallExpression',
+                callee: {
+                    type: 'Identifier',
+                    name: 'foo',
+                    range: [0, 3],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 3 }
+                    }
+                },
+                'arguments': [{
+                    type: 'ArrowFunctionExpression',
+                    id: null,
+                    params: [{
+                        type: 'Identifier',
+                        name: 'x',
+                        range: [5, 6],
+                        loc: {
+                            start: { line: 1, column: 5 },
+                            end: { line: 1, column: 6 }
+                        }
+                    }, {
+                        type: 'Identifier',
+                        name: 'y',
+                        range: [8, 9],
+                        loc: {
+                            start: { line: 1, column: 8 },
+                            end: { line: 1, column: 9 }
+                        }
+                    }],
+                    defaults: [],
+                    body: {
+                        type: 'BlockStatement',
+                        body: [],
+                        range: [15, 17],
+                        loc: {
+                            start: { line: 1, column: 15 },
+                            end: { line: 1, column: 17 }
+                        }
+                    },
+                    rest: null,
+                    generator: false,
+                    expression: false,
+                    range: [4, 17],
+                    loc: {
+                        start: { line: 1, column: 4 },
+                        end: { line: 1, column: 17 }
+                    }
+                }],
+                range: [0, 18],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 18 }
+                }
+            },
+            range: [0, 18],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 18 }
             }
         }
-
     },
-
 
     // ECMAScript 6th Syntax, 13.13 Method Definitions
 
@@ -11370,7 +11433,7 @@ var harmonyTestFixture = {
     // ECMAScript 6th Syntax, 13 - Rest parameters
     // http://wiki.ecmascript.org/doku.php?id=harmony:rest_parameters
     'ES6: Rest parameters': {
-        'function f(a, ...b) {}': {
+        'function f(a, ...b ) {}': {
             type: 'FunctionDeclaration',
             id: {
                 type: 'Identifier',
@@ -11394,10 +11457,10 @@ var harmonyTestFixture = {
             body: {
                 type: 'BlockStatement',
                 body: [],
-                range: [20, 22],
+                range: [21, 23],
                 loc: {
-                    start: { line: 1, column: 20 },
-                    end: { line: 1, column: 22 }
+                    start: { line: 1, column: 21 },
+                    end: { line: 1, column: 23 }
                 }
             },
             rest: {
@@ -11411,12 +11474,60 @@ var harmonyTestFixture = {
             },
             generator: false,
             expression: false,
-            range: [0, 22],
+            range: [0, 23],
             loc: {
                 start: { line: 1, column: 0 },
-                end: { line: 1, column: 22 }
+                end: { line: 1, column: 23 }
             }
-        }
+        },
+
+        'function f(a, ...b,) {}': {
+            type: 'FunctionDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'f',
+                range: [9, 10],
+                loc: {
+                    start: { line: 1, column: 9 },
+                    end: { line: 1, column: 10 }
+                }
+            },
+            params: [{
+                type: 'Identifier',
+                name: 'a',
+                range: [11, 12],
+                loc: {
+                    start: { line: 1, column: 11 },
+                    end: { line: 1, column: 12 }
+                }
+            }],
+            defaults: [],
+            body: {
+                type: 'BlockStatement',
+                body: [],
+                range: [21, 23],
+                loc: {
+                    start: { line: 1, column: 21 },
+                    end: { line: 1, column: 23 }
+                }
+            },
+            rest: {
+                type: 'Identifier',
+                name: 'b',
+                range: [17, 18],
+                loc: {
+                    start: { line: 1, column: 17 },
+                    end: { line: 1, column: 18 }
+                }
+            },
+            generator: false,
+            expression: false,
+            range: [0, 23],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 23 }
+            }
+        },
     },
 
     'ES6: Destructured Parameters': {
@@ -12858,7 +12969,7 @@ var harmonyTestFixture = {
             }
         },
 
-        '(a, ...b) => {}': {
+        '(a, ...b ) => {}': {
             type: 'ExpressionStatement',
             expression: {
                 type: 'ArrowFunctionExpression',
@@ -12876,10 +12987,10 @@ var harmonyTestFixture = {
                 body: {
                     type: 'BlockStatement',
                     body: [],
-                    range: [13, 15],
+                    range: [14, 16],
                     loc: {
-                        start: { line: 1, column: 13 },
-                        end: { line: 1, column: 15 }
+                        start: { line: 1, column: 14 },
+                        end: { line: 1, column: 16 }
                     }
                 },
                 rest: {
@@ -12893,16 +13004,64 @@ var harmonyTestFixture = {
                 },
                 generator: false,
                 expression: false,
-                range: [0, 15],
+                range: [0, 16],
                 loc: {
                     start: { line: 1, column: 0 },
-                    end: { line: 1, column: 15 }
+                    end: { line: 1, column: 16 }
                 }
             },
-            range: [0, 15],
+            range: [0, 16],
             loc: {
                 start: { line: 1, column: 0 },
-                end: { line: 1, column: 15 }
+                end: { line: 1, column: 16 }
+            }
+        },
+
+        '(a, ...b,) => {}': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'ArrowFunctionExpression',
+                id: null,
+                params: [{
+                    type: 'Identifier',
+                    name: 'a',
+                    range: [1, 2],
+                    loc: {
+                        start: { line: 1, column: 1 },
+                        end: { line: 1, column: 2 }
+                    }
+                }],
+                defaults: [],
+                body: {
+                    type: 'BlockStatement',
+                    body: [],
+                    range: [14, 16],
+                    loc: {
+                        start: { line: 1, column: 14 },
+                        end: { line: 1, column: 16 }
+                    }
+                },
+                rest: {
+                    type: 'Identifier',
+                    name: 'b',
+                    range: [7, 8],
+                    loc: {
+                        start: { line: 1, column: 7 },
+                        end: { line: 1, column: 8 }
+                    }
+                },
+                generator: false,
+                expression: false,
+                range: [0, 16],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 16 }
+                }
+            },
+            range: [0, 16],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 16 }
             }
         },
 
@@ -15983,11 +16142,18 @@ var harmonyTestFixture = {
             message: 'Error: Line 1: Spread must be the final element of an element list'
         },
 
-        'if (b,...a, );': {
+        'if (b,...a);': {
             index: 10,
             lineNumber: 1,
             column: 11,
-            message: 'Error: Line 1: Spread must be the final element of an element list'
+            message: 'Error: Line 1: Illegal spread element'
+        },
+
+        'if (b,...a, );': {
+            index: 11,
+            lineNumber: 1,
+            column: 12,
+            message: 'Error: Line 1: Illegal spread element'
         },
 
         '(b, ...a)': {


### PR DESCRIPTION
One thing that I like about Hack is that you can use trailing commas while declaring function parameters. We went a step forward supporting trailing commas inside arrays and objects, but it's annoying that functions don't support it.
We currently can't do this because that is not allowed on the language and the parser throws an error.
This diff makes the parser ignore trailing commas inside function parameters and expressions, even when a rest parameter is included.

Examples of currently invalid code that becomes parseable:

```
function(a, b,) {};
function(a, b, ...c,) {};
(a,) => null
(a, ...b,) => null
```

This could also be implemented with a `allowTrailingCommas` option, so this behavior would only be allowed if this options is set to true, defaulting to false.

Note: Coverage is not 100% but I'll gladly get to that if people like this diff.
