### PR TITLE
Cherry-pick lost commits

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -492,25 +492,91 @@ parseYieldExpression: true, parseAwaitExpression: true
 
     // 7.4 Comments
 
+    function addComment(type, value, start, end, loc) {
+        var comment;
+        assert(typeof start === 'number', 'Comment must have valid position');
+
+        // Because the way the actual token is scanned, often the comments
+        // (if any) are skipped twice during the lexical analysis.
+        // Thus, we need to skip adding a comment if the comment array already
+        // handled it.
+        if (extra.comments.length > 0) {
+            if (extra.comments[extra.comments.length - 1].range[1] > start) {
+                return;
+            }
+        }
+
+        comment = {
+            type: type,
+            value: value
+        };
+        if (extra.range) {
+            comment.range = [start, end];
+        }
+        if (extra.loc) {
+            comment.loc = loc;
+        }
+        extra.comments.push(comment);
+        if (extra.attachComment) {
+            extra.leadingComments.push(comment);
+            extra.trailingComments.push(comment);
+        }
+    }
+
     function skipSingleLineComment() {
-        var ch;
+        var start, loc, ch, comment;
+
+        start = index - 2;
+        loc = {
+            start: {
+                line: lineNumber,
+                column: index - lineStart - 2
+            }
+        };
 
         while (index < length) {
             ch = source.charCodeAt(index);
             ++index;
             if (isLineTerminator(ch)) {
+                if (extra.comments) {
+                    comment = source.slice(start + 2, index - 1);
+                    loc.end = {
+                        line: lineNumber,
+                        column: index - lineStart - 1
+                    };
+                    addComment('Line', comment, start, index - 1, loc);
+                }
                 if (ch === 13 && source.charCodeAt(index) === 10) {
                     ++index;
                 }
                 ++lineNumber;
                 lineStart = index;
-                break;
+                return;
             }
+        }
+
+        if (extra.comments) {
+            comment = source.slice(start + 2, index);
+            loc.end = {
+                line: lineNumber,
+                column: index - lineStart
+            };
+            addComment('Line', comment, start, index, loc);
         }
     }
 
     function skipMultiLineComment() {
-        var ch;
+        var start, loc, ch, comment;
+
+        if (extra.comments) {
+            start = index - 2;
+            loc = {
+                start: {
+                    line: lineNumber,
+                    column: index - lineStart - 2
+                }
+            };
+        }
 
         while (index < length) {
             ch = source.charCodeAt(index);
@@ -529,6 +595,14 @@ parseYieldExpression: true, parseAwaitExpression: true
                 if (source.charCodeAt(index + 1) === 47) {
                     ++index;
                     ++index;
+                    if (extra.comments) {
+                        comment = source.slice(start + 2, index - 2);
+                        loc.end = {
+                            line: lineNumber,
+                            column: index - lineStart
+                        };
+                        addComment('Block', comment, start, index, loc);
+                    }
                     return;
                 }
                 ++index;
@@ -6442,161 +6516,25 @@ parseYieldExpression: true, parseAwaitExpression: true
         return markerApply(marker, delegate.createProgram(body));
     }
 
-    // The following functions are needed only when the option to preserve
-    // the comments is active.
+    function filterCommentLocation() {
+        var i, entry, comment, comments = [];
 
-    function addComment(type, value, start, end, loc) {
-        var comment;
-
-        assert(typeof start === 'number', 'Comment must have valid position');
-
-        // Because the way the actual token is scanned, often the comments
-        // (if any) are skipped twice during the lexical analysis.
-        // Thus, we need to skip adding a comment if the comment array already
-        // handled it.
-        if (state.lastCommentStart >= start) {
-            return;
-        }
-        state.lastCommentStart = start;
-
-        comment = {
-            type: type,
-            value: value
-        };
-        if (extra.range) {
-            comment.range = [start, end];
-        }
-        if (extra.loc) {
-            comment.loc = loc;
-        }
-        extra.comments.push(comment);
-        if (extra.attachComment) {
-            extra.leadingComments.push(comment);
-            extra.trailingComments.push(comment);
-        }
-    }
-
-    function scanComment() {
-        var comment, ch, loc, start, blockComment, lineComment;
-
-        comment = '';
-        blockComment = false;
-        lineComment = false;
-
-        while (index < length) {
-            ch = source[index];
-
-            if (lineComment) {
-                ch = source[index++];
-                if (isLineTerminator(ch.charCodeAt(0))) {
-                    loc.end = {
-                        line: lineNumber,
-                        column: index - lineStart - 1
-                    };
-                    lineComment = false;
-                    addComment('Line', comment, start, index - 1, loc);
-                    if (ch === '\r' && source[index] === '\n') {
-                        ++index;
-                    }
-                    ++lineNumber;
-                    lineStart = index;
-                    comment = '';
-                } else if (index >= length) {
-                    lineComment = false;
-                    comment += ch;
-                    loc.end = {
-                        line: lineNumber,
-                        column: length - lineStart
-                    };
-                    addComment('Line', comment, start, length, loc);
-                } else {
-                    comment += ch;
-                }
-            } else if (blockComment) {
-                if (isLineTerminator(ch.charCodeAt(0))) {
-                    if (ch === '\r') {
-                        ++index;
-                        comment += '\r';
-                    }
-                    if (ch !== '\r' || source[index] === '\n') {
-                        comment += source[index];
-                        ++lineNumber;
-                        ++index;
-                        lineStart = index;
-                        if (index >= length) {
-                            throwError({}, Messages.UnexpectedToken, 'ILLEGAL');
-                        }
-                    }
-                } else {
-                    ch = source[index++];
-                    if (index >= length) {
-                        throwError({}, Messages.UnexpectedToken, 'ILLEGAL');
-                    }
-                    comment += ch;
-                    if (ch === '*') {
-                        ch = source[index];
-                        if (ch === '/') {
-                            comment = comment.substr(0, comment.length - 1);
-                            blockComment = false;
-                            ++index;
-                            loc.end = {
-                                line: lineNumber,
-                                column: index - lineStart
-                            };
-                            addComment('Block', comment, start, index, loc);
-                            comment = '';
-                        }
-                    }
-                }
-            } else if (ch === '/') {
-                ch = source[index + 1];
-                if (ch === '/') {
-                    loc = {
-                        start: {
-                            line: lineNumber,
-                            column: index - lineStart
-                        }
-                    };
-                    start = index;
-                    index += 2;
-                    lineComment = true;
-                    if (index >= length) {
-                        loc.end = {
-                            line: lineNumber,
-                            column: index - lineStart
-                        };
-                        lineComment = false;
-                        addComment('Line', comment, start, index, loc);
-                    }
-                } else if (ch === '*') {
-                    start = index;
-                    index += 2;
-                    blockComment = true;
-                    loc = {
-                        start: {
-                            line: lineNumber,
-                            column: index - lineStart - 2
-                        }
-                    };
-                    if (index >= length) {
-                        throwError({}, Messages.UnexpectedToken, 'ILLEGAL');
-                    }
-                } else {
-                    break;
-                }
-            } else if (isWhiteSpace(ch.charCodeAt(0))) {
-                ++index;
-            } else if (isLineTerminator(ch.charCodeAt(0))) {
-                ++index;
-                if (ch ===  '\r' && source[index] === '\n') {
-                    ++index;
-                }
-                ++lineNumber;
-                lineStart = index;
-            } else {
-                break;
+        for (i = 0; i < extra.comments.length; ++i) {
+            entry = extra.comments[i];
+            comment = {
+                type: entry.type,
+                value: entry.value
+            };
+            if (extra.range) {
+                comment.range = entry.range;
             }
+            if (extra.loc) {
+                comment.loc = entry.loc;
+            }
+            comments.push(comment);
         }
+
+        extra.comments = comments;
     }
 
     // 16 XJS
@@ -7562,11 +7500,6 @@ parseYieldExpression: true, parseAwaitExpression: true
     }
 
     function patch() {
-        if (extra.comments) {
-            extra.skipComment = skipComment;
-            skipComment = scanComment;
-        }
-
         if (typeof extra.tokens !== 'undefined') {
             extra.advance = advance;
             extra.scanRegExp = scanRegExp;
@@ -7577,10 +7510,6 @@ parseYieldExpression: true, parseAwaitExpression: true
     }
 
     function unpatch() {
-        if (typeof extra.skipComment === 'function') {
-            skipComment = extra.skipComment;
-        }
-
         if (typeof extra.scanRegExp === 'function') {
             advance = extra.advance;
             scanRegExp = extra.scanRegExp;

--- a/esprima.js
+++ b/esprima.js
@@ -492,69 +492,61 @@ parseYieldExpression: true, parseAwaitExpression: true
 
     // 7.4 Comments
 
-    function skipComment() {
-        var ch, blockComment, lineComment;
+    function skipSingleLineComment() {
+        var ch;
 
-        blockComment = false;
-        lineComment = false;
+        while (index < length) {
+            ch = source.charCodeAt(index);
+            ++index;
+            if (isLineTerminator(ch)) {
+                if (ch === 13 && source.charCodeAt(index) === 10) {
+                    ++index;
+                }
+                ++lineNumber;
+                lineStart = index;
+                break;
+            }
+        }
+    }
+
+    function skipMultiLineComment() {
+        var ch;
+
+        while (index < length) {
+            ch = source.charCodeAt(index);
+            if (isLineTerminator(ch)) {
+                if (ch === 13 && source.charCodeAt(index + 1) === 10) {
+                    ++index;
+                }
+                ++lineNumber;
+                ++index;
+                lineStart = index;
+                if (index >= length) {
+                    throwError({}, Messages.UnexpectedToken, 'ILLEGAL');
+                }
+            } else if (ch === 42) {
+                // Block comment ends with '*/' (char #42, char #47).
+                if (source.charCodeAt(index + 1) === 47) {
+                    ++index;
+                    ++index;
+                    return;
+                }
+                ++index;
+            } else {
+                ++index;
+            }
+        }
+
+        throwError({}, Messages.UnexpectedToken, 'ILLEGAL');
+    }
+
+    function skipComment() {
+        var ch;
 
         while (index < length) {
             ch = source.charCodeAt(index);
 
-            if (lineComment) {
-                ++index;
-                if (isLineTerminator(ch)) {
-                    lineComment = false;
-                    if (ch === 13 && source.charCodeAt(index) === 10) {
-                        ++index;
-                    }
-                    ++lineNumber;
-                    lineStart = index;
-                }
-            } else if (blockComment) {
-                if (isLineTerminator(ch)) {
-                    if (ch === 13) {
-                        ++index;
-                    }
-                    if (ch !== 13 || source.charCodeAt(index) === 10) {
-                        ++lineNumber;
-                        ++index;
-                        lineStart = index;
-                        if (index >= length) {
-                            throwError({}, Messages.UnexpectedToken, 'ILLEGAL');
-                        }
-                    }
-                } else {
-                    ch = source.charCodeAt(index++);
-                    if (index >= length) {
-                        throwError({}, Messages.UnexpectedToken, 'ILLEGAL');
-                    }
-                    // Block comment ends with '*/' (char #42, char #47).
-                    if (ch === 42) {
-                        ch = source.charCodeAt(index);
-                        if (ch === 47) {
-                            ++index;
-                            blockComment = false;
-                        }
-                    }
-                }
-            } else if (ch === 47) {
-                ch = source.charCodeAt(index + 1);
-                // Line comment starts with '//' (char #47, char #47).
-                if (ch === 47) {
-                    index += 2;
-                    lineComment = true;
-                } else if (ch === 42) {
-                    // Block comment starts with '/*' (char #47, char #42).
-                    index += 2;
-                    blockComment = true;
-                    if (index >= length) {
-                        throwError({}, Messages.UnexpectedToken, 'ILLEGAL');
-                    }
-                } else {
-                    break;
-                }
-            } else if (isWhiteSpace(ch)) {
+            if (isWhiteSpace(ch)) {
                 ++index;
             } else if (isLineTerminator(ch)) {
                 ++index;
@@ -563,6 +555,19 @@ parseYieldExpression: true, parseAwaitExpression: true
                 }
                 ++lineNumber;
                 lineStart = index;
+            } else if (ch === 47) { // 47 is '/'
+                ch = source.charCodeAt(index + 1);
+                if (ch === 47) {
+                    ++index;
+                    ++index;
+                    skipSingleLineComment();
+                } else if (ch === 42) {  // 42 is '*'
+                    ++index;
+                    ++index;
+                    skipMultiLineComment();
+                } else {
+                    break;
+                }
             } else {
                 break;
             }

--- a/esprima.js
+++ b/esprima.js
@@ -500,11 +500,10 @@ parseYieldExpression: true, parseAwaitExpression: true
         // (if any) are skipped twice during the lexical analysis.
         // Thus, we need to skip adding a comment if the comment array already
         // handled it.
-        if (extra.comments.length > 0) {
-            if (extra.comments[extra.comments.length - 1].range[1] > start) {
-                return;
-            }
+        if (state.lastCommentStart >= start) {
+            return;
         }
+        state.lastCommentStart = start;
 
         comment = {
             type: type,
@@ -6514,27 +6513,6 @@ parseYieldExpression: true, parseAwaitExpression: true
         peek();
         body = parseProgramElements();
         return markerApply(marker, delegate.createProgram(body));
-    }
-
-    function filterCommentLocation() {
-        var i, entry, comment, comments = [];
-
-        for (i = 0; i < extra.comments.length; ++i) {
-            entry = extra.comments[i];
-            comment = {
-                type: entry.type,
-                value: entry.value
-            };
-            if (extra.range) {
-                comment.range = entry.range;
-            }
-            if (extra.loc) {
-                comment.loc = entry.loc;
-            }
-            comments.push(comment);
-        }
-
-        extra.comments = comments;
     }
 
     // 16 XJS

--- a/esprima.js
+++ b/esprima.js
@@ -6239,15 +6239,17 @@ parseYieldExpression: true, parseAwaitExpression: true
                                 ClassPropertyType['static'] :
                                 ClassPropertyType.prototype;
 
-                    if (propName === 'constructor' && !classElement['static']) {
-                        if (specialMethod(classElement)) {
-                            throwError(classElement, Messages.IllegalClassConstructorProperty);
+                    if (classElement.type === Syntax.MethodDefinition) {
+                        if (propName === 'constructor' && !classElement.static) {
+                            if (specialMethod(classElement)) {
+                                throwError(classElement, Messages.IllegalClassConstructorProperty);
+                            }
+                            if (existingProps[ClassPropertyType.prototype].has('constructor')) {
+                                throwError(classElement.key, Messages.IllegalDuplicateClassProperty);
+                            }
                         }
-                        if (existingProps[ClassPropertyType.prototype].has('constructor')) {
-                            throwError(classElement.key, Messages.IllegalDuplicateClassProperty);
-                        }
+                        existingProps[propType].set(propName, true);
                     }
-                    existingProps[propType].set(propName, true);
                 }
             }
         }

--- a/esprima.js
+++ b/esprima.js
@@ -1567,7 +1567,7 @@ parseYieldExpression: true, parseAwaitExpression: true
             }
             return scanRegExp();
         }
-        if (prevToken.type === 'Keyword') {
+        if (prevToken.type === 'Keyword' && prevToken.value !== 'this') {
             return scanRegExp();
         }
         return scanPunctuator();

--- a/test/fbtest.js
+++ b/test/fbtest.js
@@ -177,6 +177,9 @@ module.exports = {
         'var y: return',
         'var a: { x: number, y: string }',
     ],
+    'Hacky Type Annotations': [
+        'class Foo { constructor: Function; constructor(){} }',
+    ],
     'Array Types': [
       'var a: number[]',
       'var a: ?number[]',

--- a/test/fbtest.rec.js
+++ b/test/fbtest.rec.js
@@ -4,7 +4,7 @@
 * tests/fbtest.js and run tools/generate-fbtest.js
 */
 
-var numTests = 217
+var numTests = 218
 var testFixture;
 
 var fbTestFixture = {
@@ -9432,6 +9432,121 @@ var fbTestFixture = {
             message: 'Error: Line 1: Unexpected token ,',
             description: 'Unexpected token ,'
 
+        },
+    },
+    'Hacky Type Annotations': {
+        'class Foo { constructor: Function; constructor(){} }': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'Foo',
+                range: [6, 9],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 9 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'ClassProperty',
+                    key: {
+                        type: 'Identifier',
+                        name: 'constructor',
+                        range: [12, 23],
+                        loc: {
+                            start: { line: 1, column: 12 },
+                            end: { line: 1, column: 23 }
+                        }
+                    },
+                    typeAnnotation: {
+                        type: 'TypeAnnotation',
+                        typeAnnotation: {
+                            type: 'GenericTypeAnnotation',
+                            id: {
+                                type: 'Identifier',
+                                name: 'Function',
+                                range: [25, 33],
+                                loc: {
+                                    start: { line: 1, column: 25 },
+                                    end: { line: 1, column: 33 }
+                                }
+                            },
+                            typeParameters: null,
+                            range: [25, 33],
+                            loc: {
+                                start: { line: 1, column: 25 },
+                                end: { line: 1, column: 33 }
+                            }
+                        },
+                        range: [23, 33],
+                        loc: {
+                            start: { line: 1, column: 23 },
+                            end: { line: 1, column: 33 }
+                        }
+                    },
+                    computed: false,
+                    'static': false,
+                    range: [12, 34],
+                    loc: {
+                        start: { line: 1, column: 12 },
+                        end: { line: 1, column: 34 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'constructor',
+                        range: [35, 46],
+                        loc: {
+                            start: { line: 1, column: 35 },
+                            end: { line: 1, column: 46 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [48, 50],
+                            loc: {
+                                start: { line: 1, column: 48 },
+                                end: { line: 1, column: 50 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [48, 50],
+                        loc: {
+                            start: { line: 1, column: 48 },
+                            end: { line: 1, column: 50 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    computed: false,
+                    range: [35, 50],
+                    loc: {
+                        start: { line: 1, column: 35 },
+                        end: { line: 1, column: 50 }
+                    }
+                }],
+                range: [10, 52],
+                loc: {
+                    start: { line: 1, column: 10 },
+                    end: { line: 1, column: 52 }
+                }
+            },
+            range: [0, 52],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 52 }
+            }
         },
     },
     'Array Types': {

--- a/test/harmonytest.js
+++ b/test/harmonytest.js
@@ -9934,54 +9934,6 @@ var harmonyTestFixture = {
             }
         },
 
-        'class A { get foo() {} get foo() {} }': {
-            index: 30,
-            lineNumber: 1,
-            column: 31,
-            message: 'Error: Line 1: Illegal duplicate property in class definition',
-            description: 'Illegal duplicate property in class definition'
-        },
-
-        'class A { set foo(v) {} set foo(v) {} }': {
-            index: 31,
-            lineNumber: 1,
-            column: 32,
-            message: 'Error: Line 1: Illegal duplicate property in class definition',
-            description: 'Illegal duplicate property in class definition'
-        },
-
-        'class A { get foo() {} foo() {} }': {
-            index: 26,
-            lineNumber: 1,
-            column: 27,
-            message: 'Error: Line 1: Illegal duplicate property in class definition',
-            description: 'Illegal duplicate property in class definition'
-        },
-
-        'class A { foo() {} get foo() {} }': {
-            index: 26,
-            lineNumber: 1,
-            column: 27,
-            message: 'Error: Line 1: Illegal duplicate property in class definition',
-            description: 'Illegal duplicate property in class definition'
-        },
-
-        'class A { set foo(v) {} foo() {} }': {
-            index: 27,
-            lineNumber: 1,
-            column: 28,
-            message: 'Error: Line 1: Illegal duplicate property in class definition',
-            description: 'Illegal duplicate property in class definition'
-        },
-
-        'class A { foo() {} set foo(v) {} }': {
-            index: 26,
-            lineNumber: 1,
-            column: 27,
-            message: 'Error: Line 1: Illegal duplicate property in class definition',
-            description: 'Illegal duplicate property in class definition'
-        },
-
         'class A { get [x]() {} get[x]() {} }': {
             type: 'ClassDeclaration',
             id: {
@@ -10453,6 +10405,1658 @@ var harmonyTestFixture = {
                 start: { line: 1, column: 0 },
                 end: { line: 1, column: 93 }
             }
+        },
+
+'class A { static [foo]() {} static foo() {} }': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [18, 21],
+                        loc: {
+                            start: { line: 1, column: 18 },
+                            end: { line: 1, column: 21 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [25, 27],
+                            loc: {
+                                start: { line: 1, column: 25 },
+                                end: { line: 1, column: 27 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [25, 27],
+                        loc: {
+                            start: { line: 1, column: 25 },
+                            end: { line: 1, column: 27 }
+                        }
+                    },
+                    kind: '',
+                    'static': true,
+                    computed: true,
+                    range: [10, 27],
+                    loc: {
+                        start: { line: 1, column: 10 },
+                        end: { line: 1, column: 27 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [35, 38],
+                        loc: {
+                            start: { line: 1, column: 35 },
+                            end: { line: 1, column: 38 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [41, 43],
+                            loc: {
+                                start: { line: 1, column: 41 },
+                                end: { line: 1, column: 43 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [41, 43],
+                        loc: {
+                            start: { line: 1, column: 41 },
+                            end: { line: 1, column: 43 }
+                        }
+                    },
+                    kind: '',
+                    'static': true,
+                    computed: false,
+                    range: [28, 43],
+                    loc: {
+                        start: { line: 1, column: 28 },
+                        end: { line: 1, column: 43 }
+                    }
+                }],
+                range: [8, 45],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 45 }
+                }
+            },
+            range: [0, 45],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 45 }
+            }
+        },
+
+        'class A { [foo]() {} foo() {} }': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [11, 14],
+                        loc: {
+                            start: { line: 1, column: 11 },
+                            end: { line: 1, column: 14 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [18, 20],
+                            loc: {
+                                start: { line: 1, column: 18 },
+                                end: { line: 1, column: 20 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [18, 20],
+                        loc: {
+                            start: { line: 1, column: 18 },
+                            end: { line: 1, column: 20 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    computed: true,
+                    range: [10, 20],
+                    loc: {
+                        start: { line: 1, column: 10 },
+                        end: { line: 1, column: 20 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [21, 24],
+                        loc: {
+                            start: { line: 1, column: 21 },
+                            end: { line: 1, column: 24 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [27, 29],
+                            loc: {
+                                start: { line: 1, column: 27 },
+                                end: { line: 1, column: 29 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [27, 29],
+                        loc: {
+                            start: { line: 1, column: 27 },
+                            end: { line: 1, column: 29 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    computed: false,
+                    range: [21, 29],
+                    loc: {
+                        start: { line: 1, column: 21 },
+                        end: { line: 1, column: 29 }
+                    }
+                }],
+                range: [8, 31],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 31 }
+                }
+            },
+            range: [0, 31],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 31 }
+            }
+        },
+
+        'class A { get [foo]() {} set [foo](v) {} get foo() {} set foo(v) {} }': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [15, 18],
+                        loc: {
+                            start: { line: 1, column: 15 },
+                            end: { line: 1, column: 18 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [22, 24],
+                            loc: {
+                                start: { line: 1, column: 22 },
+                                end: { line: 1, column: 24 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [22, 24],
+                        loc: {
+                            start: { line: 1, column: 22 },
+                            end: { line: 1, column: 24 }
+                        }
+                    },
+                    kind: 'get',
+                    'static': false,
+                    computed: true,
+                    range: [10, 24],
+                    loc: {
+                        start: { line: 1, column: 10 },
+                        end: { line: 1, column: 24 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [30, 33],
+                        loc: {
+                            start: { line: 1, column: 30 },
+                            end: { line: 1, column: 33 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [{
+                            type: 'Identifier',
+                            name: 'v',
+                            range: [35, 36],
+                            loc: {
+                                start: { line: 1, column: 35 },
+                                end: { line: 1, column: 36 }
+                            }
+                        }],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [38, 40],
+                            loc: {
+                                start: { line: 1, column: 38 },
+                                end: { line: 1, column: 40 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [38, 40],
+                        loc: {
+                            start: { line: 1, column: 38 },
+                            end: { line: 1, column: 40 }
+                        }
+                    },
+                    kind: 'set',
+                    'static': false,
+                    computed: true,
+                    range: [25, 40],
+                    loc: {
+                        start: { line: 1, column: 25 },
+                        end: { line: 1, column: 40 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [45, 48],
+                        loc: {
+                            start: { line: 1, column: 45 },
+                            end: { line: 1, column: 48 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [51, 53],
+                            loc: {
+                                start: { line: 1, column: 51 },
+                                end: { line: 1, column: 53 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [51, 53],
+                        loc: {
+                            start: { line: 1, column: 51 },
+                            end: { line: 1, column: 53 }
+                        }
+                    },
+                    kind: 'get',
+                    'static': false,
+                    computed: false,
+                    range: [41, 53],
+                    loc: {
+                        start: { line: 1, column: 41 },
+                        end: { line: 1, column: 53 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [58, 61],
+                        loc: {
+                            start: { line: 1, column: 58 },
+                            end: { line: 1, column: 61 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [{
+                            type: 'Identifier',
+                            name: 'v',
+                            range: [62, 63],
+                            loc: {
+                                start: { line: 1, column: 62 },
+                                end: { line: 1, column: 63 }
+                            }
+                        }],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [65, 67],
+                            loc: {
+                                start: { line: 1, column: 65 },
+                                end: { line: 1, column: 67 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [65, 67],
+                        loc: {
+                            start: { line: 1, column: 65 },
+                            end: { line: 1, column: 67 }
+                        }
+                    },
+                    kind: 'set',
+                    'static': false,
+                    computed: false,
+                    range: [54, 67],
+                    loc: {
+                        start: { line: 1, column: 54 },
+                        end: { line: 1, column: 67 }
+                    }
+                }],
+                range: [8, 69],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 69 }
+                }
+            },
+            range: [0, 69],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 69 }
+            }
+        },
+
+        'class A { *[foo]() {} *foo() {} }': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [12, 15],
+                        loc: {
+                            start: { line: 1, column: 12 },
+                            end: { line: 1, column: 15 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [19, 21],
+                            loc: {
+                                start: { line: 1, column: 19 },
+                                end: { line: 1, column: 21 }
+                            }
+                        },
+                        rest: null,
+                        generator: true,
+                        expression: false,
+                        range: [19, 21],
+                        loc: {
+                            start: { line: 1, column: 19 },
+                            end: { line: 1, column: 21 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    computed: true,
+                    range: [10, 21],
+                    loc: {
+                        start: { line: 1, column: 10 },
+                        end: { line: 1, column: 21 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [23, 26],
+                        loc: {
+                            start: { line: 1, column: 23 },
+                            end: { line: 1, column: 26 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [29, 31],
+                            loc: {
+                                start: { line: 1, column: 29 },
+                                end: { line: 1, column: 31 }
+                            }
+                        },
+                        rest: null,
+                        generator: true,
+                        expression: false,
+                        range: [29, 31],
+                        loc: {
+                            start: { line: 1, column: 29 },
+                            end: { line: 1, column: 31 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    computed: false,
+                    range: [22, 31],
+                    loc: {
+                        start: { line: 1, column: 22 },
+                        end: { line: 1, column: 31 }
+                    }
+                }],
+                range: [8, 33],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 33 }
+                }
+            },
+            range: [0, 33],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 33 }
+            }
+        },
+
+        'class A { get foo() {} get foo() {} }': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [14, 17],
+                        loc: {
+                            start: { line: 1, column: 14 },
+                            end: { line: 1, column: 17 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                           type: 'BlockStatement',
+                           body: [],
+                           range: [20, 22],
+                           loc: {
+                               start: { line: 1, column: 20 },
+                               end: { line: 1, column: 22 }
+                           }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [20, 22],
+                        loc: {
+                           start: { line: 1, column: 20 },
+                           end: { line: 1, column: 22 }
+                        }
+                    },
+                    kind: 'get',
+                    'static': false,
+                    computed: false,
+                    range: [10, 22],
+                    loc: {
+                        start: { line: 1, column: 10 },
+                        end: { line: 1, column: 22 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [27, 30],
+                        loc: {
+                            start: { line: 1, column: 27 },
+                            end: { line: 1, column: 30 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                           type: 'BlockStatement',
+                           body: [],
+                           range: [33, 35],
+                           loc: {
+                               start: { line: 1, column: 33 },
+                               end: { line: 1, column: 35 }
+                           }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [33, 35],
+                        loc: {
+                           start: { line: 1, column: 33 },
+                           end: { line: 1, column: 35 }
+                        }
+                    },
+                    kind: 'get',
+                    'static': false,
+                    computed: false,
+                    range: [23, 35],
+                    loc: {
+                        start: { line: 1, column: 23 },
+                        end: { line: 1, column: 35 }
+                    }
+                }],
+                range: [8, 37],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 37 }
+                }
+            },
+            range: [0, 37],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 37 }
+            }
+        },
+
+        'class A { set foo(v) {} set foo(v) {} }': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [14, 17],
+                        loc: {
+                            start: { line: 1, column: 14 },
+                            end: { line: 1, column: 17 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [{
+                           type: 'Identifier',
+                           name: 'v',
+                           range: [18, 19],
+                           loc: {
+                               start: { line: 1, column: 18 },
+                               end: { line: 1, column: 19 }
+                           }
+                        }],
+                        defaults: [],
+                        body: {
+                           type: 'BlockStatement',
+                           body: [],
+                           range: [21, 23],
+                           loc: {
+                               start: { line: 1, column: 21 },
+                               end: { line: 1, column: 23 }
+                           }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [21, 23],
+                        loc: {
+                           start: { line: 1, column: 21 },
+                           end: { line: 1, column: 23 }
+                        }
+                    },
+                    kind: 'set',
+                    'static': false,
+                    computed: false,
+                    range: [10, 23],
+                    loc: {
+                        start: { line: 1, column: 10 },
+                        end: { line: 1, column: 23 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [28, 31],
+                        loc: {
+                            start: { line: 1, column: 28 },
+                            end: { line: 1, column: 31 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [{
+                           type: 'Identifier',
+                           name: 'v',
+                           range: [32, 33],
+                           loc: {
+                               start: { line: 1, column: 32 },
+                               end: { line: 1, column: 33 }
+                           }
+                        }],
+                        defaults: [],
+                        body: {
+                           type: 'BlockStatement',
+                           body: [],
+                           range: [35, 37],
+                           loc: {
+                               start: { line: 1, column: 35 },
+                               end: { line: 1, column: 37 }
+                           }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [35, 37],
+                        loc: {
+                           start: { line: 1, column: 35 },
+                           end: { line: 1, column: 37 }
+                        }
+                    },
+                    kind: 'set',
+                    'static': false,
+                    computed: false,
+                    range: [24, 37],
+                    loc: {
+                        start: { line: 1, column: 24 },
+                        end: { line: 1, column: 37 }
+                    }
+                }],
+                range: [8, 39],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 39 }
+                }
+            },
+            range: [0, 39],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 39 }
+            }
+        },
+
+        'class A { get foo() {} foo() {} }': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [14, 17],
+                        loc: {
+                            start: { line: 1, column: 14 },
+                            end: { line: 1, column: 17 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                           type: 'BlockStatement',
+                           body: [],
+                           range: [20, 22],
+                           loc: {
+                               start: { line: 1, column: 20 },
+                               end: { line: 1, column: 22 }
+                           }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [20, 22],
+                        loc: {
+                           start: { line: 1, column: 20 },
+                           end: { line: 1, column: 22 }
+                        }
+                    },
+                    kind: 'get',
+                    'static': false,
+                    computed: false,
+                    range: [10, 22],
+                    loc: {
+                        start: { line: 1, column: 10 },
+                        end: { line: 1, column: 22 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [23, 26],
+                        loc: {
+                            start: { line: 1, column: 23 },
+                            end: { line: 1, column: 26 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                           type: 'BlockStatement',
+                           body: [],
+                           range: [29, 31],
+                           loc: {
+                               start: { line: 1, column: 29 },
+                               end: { line: 1, column: 31 }
+                           }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [29, 31],
+                        loc: {
+                           start: { line: 1, column: 29 },
+                           end: { line: 1, column: 31 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    computed: false,
+                    range: [23, 31],
+                    loc: {
+                        start: { line: 1, column: 23 },
+                        end: { line: 1, column: 31 }
+                    }
+                }],
+                range: [8, 33],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 33 }
+                }
+            },
+            range: [0, 33],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 33 }
+            }
+        },
+
+        'class A { foo() {} get foo() {} }': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [10, 13],
+                        loc: {
+                            start: { line: 1, column: 10 },
+                            end: { line: 1, column: 13 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                           type: 'BlockStatement',
+                           body: [],
+                           range: [16, 18],
+                           loc: {
+                               start: { line: 1, column: 16 },
+                               end: { line: 1, column: 18 }
+                           }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [16, 18],
+                        loc: {
+                           start: { line: 1, column: 16 },
+                           end: { line: 1, column: 18 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    computed: false,
+                    range: [10, 18],
+                    loc: {
+                        start: { line: 1, column: 10 },
+                        end: { line: 1, column: 18 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [23, 26],
+                        loc: {
+                            start: { line: 1, column: 23 },
+                            end: { line: 1, column: 26 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                           type: 'BlockStatement',
+                           body: [],
+                           range: [29, 31],
+                           loc: {
+                               start: { line: 1, column: 29 },
+                               end: { line: 1, column: 31 }
+                           }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [29, 31],
+                        loc: {
+                           start: { line: 1, column: 29 },
+                           end: { line: 1, column: 31 }
+                        }
+                    },
+                    kind: 'get',
+                    'static': false,
+                    computed: false,
+                    range: [19, 31],
+                    loc: {
+                        start: { line: 1, column: 19 },
+                        end: { line: 1, column: 31 }
+                    }
+                }],
+                range: [8, 33],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 33 }
+                }
+            },
+            range: [0, 33],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 33 }
+            }
+        },
+
+        'class A { set foo(v) {} foo() {} }': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [14, 17],
+                        loc: {
+                            start: { line: 1, column: 14 },
+                            end: { line: 1, column: 17 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [{
+                           type: 'Identifier',
+                           name: 'v',
+                           range: [18, 19],
+                           loc: {
+                               start: { line: 1, column: 18 },
+                               end: { line: 1, column: 19 }
+                           }
+                        }],
+                        defaults: [],
+                        body: {
+                           type: 'BlockStatement',
+                           body: [],
+                           range: [21, 23],
+                           loc: {
+                               start: { line: 1, column: 21 },
+                               end: { line: 1, column: 23 }
+                           }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [21, 23],
+                        loc: {
+                           start: { line: 1, column: 21 },
+                           end: { line: 1, column: 23 }
+                        }
+                    },
+                    kind: 'set',
+                    'static': false,
+                    computed: false,
+                    range: [10, 23],
+                    loc: {
+                        start: { line: 1, column: 10 },
+                        end: { line: 1, column: 23 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [24, 27],
+                        loc: {
+                            start: { line: 1, column: 24 },
+                            end: { line: 1, column: 27 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                           type: 'BlockStatement',
+                           body: [],
+                           range: [30, 32],
+                           loc: {
+                               start: { line: 1, column: 30 },
+                               end: { line: 1, column: 32 }
+                           }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [30, 32],
+                        loc: {
+                           start: { line: 1, column: 30 },
+                           end: { line: 1, column: 32 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    computed: false,
+                    range: [24, 32],
+                    loc: {
+                        start: { line: 1, column: 24 },
+                        end: { line: 1, column: 32 }
+                    }
+                }],
+                range: [8, 34],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 34 }
+                }
+            },
+            range: [0, 34],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 34 }
+            }
+        },
+
+        'class A { foo() {} set foo(v) {} }': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [10, 13],
+                        loc: {
+                            start: { line: 1, column: 10 },
+                            end: { line: 1, column: 13 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                           type: 'BlockStatement',
+                           body: [],
+                           range: [16, 18],
+                           loc: {
+                               start: { line: 1, column: 16 },
+                               end: { line: 1, column: 18 }
+                           }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [16, 18],
+                        loc: {
+                           start: { line: 1, column: 16 },
+                           end: { line: 1, column: 18 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    computed: false,
+                    range: [10, 18],
+                    loc: {
+                        start: { line: 1, column: 10 },
+                        end: { line: 1, column: 18 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [23, 26],
+                        loc: {
+                            start: { line: 1, column: 23 },
+                            end: { line: 1, column: 26 }
+                        }
+                    },
+                    value: {
+                       type: 'FunctionExpression',
+                       id: null,
+                       params: [{
+                           type: 'Identifier',
+                           name: 'v',
+                           range: [27, 28],
+                           loc: {
+                               start: { line: 1, column: 27 },
+                               end: { line: 1, column: 28 }
+                           }
+                       }],
+                       defaults: [],
+                       body: {
+                           type: 'BlockStatement',
+                           body: [],
+                           range: [30, 32],
+                           loc: {
+                               start: { line: 1, column: 30 },
+                               end: { line: 1, column: 32 }
+                           }
+                       },
+                       rest: null,
+                       generator: false,
+                       expression: false,
+                       range: [30, 32],
+                       loc: {
+                           start: { line: 1, column: 30 },
+                           end: { line: 1, column: 32 }
+                       }
+                    },
+                    kind: 'set',
+                    'static': false,
+                    computed: false,
+                    range: [19, 32],
+                    loc: {
+                        start: { line: 1, column: 19 },
+                        end: { line: 1, column: 32 }
+                    }
+                }],
+                range: [8, 34],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 34 }
+                }
+            },
+            range: [0, 34],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 34 }
+            }
+        },
+
+        'class A { constructor() {} static constructor() {} }': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'constructor',
+                        range: [10, 21],
+                        loc: {
+                            start: { line: 1, column: 10 },
+                            end: { line: 1, column: 21 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                           type: 'BlockStatement',
+                           body: [],
+                           range: [24, 26],
+                           loc: {
+                               start: { line: 1, column: 24 },
+                               end: { line: 1, column: 26 }
+                           }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [24, 26],
+                        loc: {
+                           start: { line: 1, column: 24 },
+                           end: { line: 1, column: 26 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    computed: false,
+                    range: [10, 26],
+                    loc: {
+                        start: { line: 1, column: 10 },
+                        end: { line: 1, column: 26 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'constructor',
+                        range: [34, 45],
+                        loc: {
+                            start: { line: 1, column: 34 },
+                            end: { line: 1, column: 45 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                           type: 'BlockStatement',
+                           body: [],
+                           range: [48, 50],
+                           loc: {
+                               start: { line: 1, column: 48 },
+                               end: { line: 1, column: 50 }
+                           }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [48, 50],
+                        loc: {
+                           start: { line: 1, column: 48 },
+                           end: { line: 1, column: 50 }
+                        }
+                    },
+                    kind: '',
+                    'static': true,
+                    computed: false,
+                    range: [27, 50],
+                    loc: {
+                        start: { line: 1, column: 27 },
+                        end: { line: 1, column: 50 }
+                    }
+                }],
+                range: [8, 52],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 52 }
+                }
+            },
+            range: [0, 52],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 52 }
+            }
+        },
+
+        'class A { static constructor() {} constructor() {} }': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'constructor',
+                        range: [17, 28],
+                        loc: {
+                            start: { line: 1, column: 17 },
+                            end: { line: 1, column: 28 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [31, 33],
+                            loc: {
+                                start: { line: 1, column: 31 },
+                                end: { line: 1, column: 33 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [31, 33],
+                        loc: {
+                            start: { line: 1, column: 31 },
+                            end: { line: 1, column: 33 }
+                        }
+                    },
+                    kind: '',
+                    'static': true,
+                    computed: false,
+                    range: [10, 33],
+                    loc: {
+                        start: { line: 1, column: 10 },
+                        end: { line: 1, column: 33 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'constructor',
+                        range: [34, 45],
+                        loc: {
+                            start: { line: 1, column: 34 },
+                            end: { line: 1, column: 45 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [48, 50],
+                            loc: {
+                                start: { line: 1, column: 48 },
+                                end: { line: 1, column: 50 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [48, 50],
+                        loc: {
+                            start: { line: 1, column: 48 },
+                            end: { line: 1, column: 50 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    computed: false,
+                    range: [34, 50],
+                    loc: {
+                        start: { line: 1, column: 34 },
+                        end: { line: 1, column: 50 }
+                    }
+                }],
+                range: [8, 52],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 52 }
+                }
+            },
+            range: [0, 52],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 52 }
+            }
+        },
+
+        'class A { constructor() {} [constructor]() {} }': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'constructor',
+                        range: [10, 21],
+                        loc: {
+                            start: { line: 1, column: 10 },
+                            end: { line: 1, column: 21 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [24, 26],
+                            loc: {
+                                start: { line: 1, column: 24 },
+                                end: { line: 1, column: 26 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [24, 26],
+                        loc: {
+                            start: { line: 1, column: 24 },
+                            end: { line: 1, column: 26 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    computed: false,
+                    range: [10, 26],
+                    loc: {
+                        start: { line: 1, column: 10 },
+                        end: { line: 1, column: 26 }
+                    }
+                }, {
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'constructor',
+                        range: [28, 39],
+                        loc: {
+                            start: { line: 1, column: 28 },
+                            end: { line: 1, column: 39 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [43, 45],
+                            loc: {
+                                start: { line: 1, column: 43 },
+                                end: { line: 1, column: 45 }
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [43, 45],
+                        loc: {
+                            start: { line: 1, column: 43 },
+                            end: { line: 1, column: 45 }
+                        }
+                    },
+                    kind: '',
+                    'static': false,
+                    computed: true,
+                    range: [27, 45],
+                    loc: {
+                        start: { line: 1, column: 27 },
+                        end: { line: 1, column: 45 }
+                    }
+                }],
+                range: [8, 47],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 47 }
+                }
+            },
+            range: [0, 47],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 47 }
+            }
+        },
+
+        'class A { constructor() {} constructor() {} }': {
+            index: 43,
+            lineNumber: 1,
+            column: 44,
+            message: 'Error: Line 1: Illegal duplicate property in class definition',
+            description: 'Illegal duplicate property in class definition'
+        },
+
+        'class A { constructor() {} "constructor"() {} }': {
+            index: 45,
+            lineNumber: 1,
+            column: 46,
+            message: 'Error: Line 1: Illegal duplicate property in class definition',
+            description: 'Illegal duplicate property in class definition'
+        },
+
+        'class A { "constructor"() {} constructor() {} }': {
+            index: 45,
+            lineNumber: 1,
+            column: 46,
+            message: 'Error: Line 1: Illegal duplicate property in class definition',
+            description: 'Illegal duplicate property in class definition'
+        },
+
+        'class A { get constructor() {} }': {
+            index: 30,
+            lineNumber: 1,
+            column: 31,
+            message: 'Error: Line 1: Illegal constructor property in class definition',
+            description: 'Illegal constructor property in class definition"'
+        },
+
+        'class A { set constructor(v) {} }': {
+            index: 31,
+            lineNumber: 1,
+            column: 32,
+            message: 'Error: Line 1: Illegal constructor property in class definition',
+            description: 'Illegal constructor property in class definition"'
+        },
+
+        'class A { *constructor() {} }': {
+            index: 27,
+            lineNumber: 1,
+            column: 28,
+            message: 'Error: Line 1: Illegal constructor property in class definition',
+            description: 'Illegal constructor property in class definition"'
+        },
+
+        'class A { constructor() {} get constructor() {} }': {
+            index: 47,
+            lineNumber: 1,
+            column: 48,
+            message: 'Error: Line 1: Illegal constructor property in class definition',
+            description: 'Illegal constructor property in class definition"'
+        },
+
+        'class A { get constructor() {} constructor() {} }': {
+            index: 30,
+            lineNumber: 1,
+            column: 31,
+            message: 'Error: Line 1: Illegal constructor property in class definition',
+            description: 'Illegal constructor property in class definition"'
         },
     },
 

--- a/test/test.js
+++ b/test/test.js
@@ -3866,14 +3866,14 @@ var testFixture = {
                     raw: '42',
                     range: [8, 10],
                     loc: {
-                        start: { line: 1, column: 8 },
-                        end: { line: 1, column: 10 }
+                        start: { line: 2, column: 4 },
+                        end: { line: 2, column: 6 }
                     }
                 },
                 range: [8, 10],
                 loc: {
-                    start: { line: 1, column: 8 },
-                    end: { line: 1, column: 10 }
+                    start: { line: 2, column: 4 },
+                    end: { line: 2, column: 6 }
                 },
                 leadingComments: [{
                     type: 'Block',
@@ -3881,14 +3881,14 @@ var testFixture = {
                     range: [0, 7],
                     loc: {
                         start: { line: 1, column: 0 },
-                        end: { line: 1, column: 7 }
+                        end: { line: 2, column: 3 }
                     }
                 }]
             }],
             range: [8, 10],
             loc: {
-                start: { line: 1, column: 8 },
-                end: { line: 1, column: 10 }
+                start: { line: 2, column: 4 },
+                end: { line: 2, column: 6 }
             },
             comments: [{
                 type: 'Block',
@@ -3896,7 +3896,7 @@ var testFixture = {
                 range: [0, 7],
                 loc: {
                     start: { line: 1, column: 0 },
-                    end: { line: 1, column: 7 }
+                    end: { line: 2, column: 3 }
                 }
             }]
         },
@@ -18043,16 +18043,16 @@ var testFixture = {
 
         '/*\n\r*/]': {
             index: 6,
-            lineNumber: 2,
-            column: 4,
-            message: 'Error: Line 2: Unexpected token ]'
+            lineNumber: 3,
+            column: 3,
+            message: 'Error: Line 3: Unexpected token ]'
         },
 
         '/*\r \n*/]': {
             index: 7,
-            lineNumber: 2,
+            lineNumber: 3,
             column: 3,
-            message: 'Error: Line 2: Unexpected token ]'
+            message: 'Error: Line 3: Unexpected token ]'
         },
 
         '\\\\': {
@@ -23173,5 +23173,5 @@ var testFixture = {
         }
 
 
-    },
+    }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -19984,8 +19984,82 @@ var testFixture = {
             lineNumber: 1,
             column: 8,
             message: 'Error: Line 1: Invalid regular expression: missing /'
-        }
+        },
 
+        'this / 100;': [
+          {
+            "type": "Keyword",
+            "value": "this",
+            "range": [
+              0,
+              4
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 4
+              }
+            }
+          },
+          {
+            "type": "Punctuator",
+            "value": "/",
+            "range": [
+              5,
+              6
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 5
+              },
+              "end": {
+                "line": 1,
+                "column": 6
+              }
+            }
+          },
+          {
+            "type": "Numeric",
+            "value": "100",
+            "range": [
+              7,
+              10
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 7
+              },
+              "end": {
+                "line": 1,
+                "column": 10
+              }
+            }
+          },
+          {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+              10,
+              11
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 10
+              },
+              "end": {
+                "line": 1,
+                "column": 11
+              }
+            }
+          }
+        ]
     },
 
     'API': {

--- a/tools/generate-test-fixture.js
+++ b/tools/generate-test-fixture.js
@@ -44,8 +44,6 @@
 
     code = cliArgs.args[0];
 
-    console.log('code', code);
-
     if (code.length === 0) {
         console.log('Usage:');
         console.log('   generate-test-fixture.js code');


### PR DESCRIPTION
This brings in several of the lost commits from #87 - these were pretty straightforward. It's still missing c0826922b4d7e66e3ae0cbc6979fd99d47258215 but that's hard and @fkling said he would do it.

There is a failing test now, which I didn't finish tracking down. For some reason our multiline comment parsing appears to be doing the wrong thing with `\n\r`, treating that as 2 newlines. Our test and upstream's expect it the be a single newline and the multiline comment parsing code is identical so I'm not really sure what's going on.

If anybody is willing to take a look - it's possible I screwed something up in the cherry-picking and missed it.
