### PR TITLE
Add support for `import type` and `export <<type alias>>` Flow syntax

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -4836,10 +4836,11 @@ parseYieldExpression: true, parseAwaitExpression: true
         }
 
         // non-default export
-        if (lookahead.type === Token.Keyword) {
+        if (lookahead.type === Token.Keyword || matchContextualKeyword('type')) {
             // covers:
             // export var f = 1;
             switch (lookahead.value) {
+            case 'type':
             case 'let':
             case 'const':
             case 'var':

--- a/test/fbtest.js
+++ b/test/fbtest.js
@@ -47,7 +47,6 @@ module.exports = {
         '<div {...props} post="attribute" />',
         '<div pre="leading" pre2="attribute" {...props}></div>',
         '<a>    </a>',
-        '<a .../*hai*/asdf/>',
         '<a>= == =</a>',
     ],
     'Invalid XJS Syntax': [
@@ -81,6 +80,7 @@ module.exports = {
         '<a b=}>',
         '<a b=<}>',
         '<a>}</a>',
+        '<a .../*hai*/asdf/>',
     ],
     'Type Annotations': [
         'function foo(numVal: any){}',
@@ -123,6 +123,7 @@ module.exports = {
         'var a: {subObj: ?{strVal: string}}',
         'var a: {param1: number; param2: string}',
         'var a: {param1: number; param2?: string}',
+        'var a: { [a: number]: string; [b: number]: string; };',
         'var a: {add(x:number, ...y:Array<string>): void}',
         'var a: { id<T>(x: T): T; }',
         'var a:Array<number> = [1, 2, 3]',
@@ -156,7 +157,10 @@ module.exports = {
         'var a: Promise<bool>[]',
         'var a:(...rest:Array<number>) => number',
         'var identity: <T>(x: T) => T',
-        'var identity: <T>(x: T, ...y:T[]) => T'
+        'var identity: <T>(x: T, ...y:T[]) => T',
+        'import type foo from "bar";',
+        'import type {foo, bar} from "baz";',
+        'import type {foo as bar} from "baz";'
     ],
     'Invalid Type Annotations': [
         'function foo(callback:) {}',
@@ -166,7 +170,6 @@ module.exports = {
         'a = {foo(): { return 42; }}',
         'class Foo { get bar<T>() { } }',
         'var a:{a:number b:string}',
-        'var a: { [a: number]: string; [b: number]: string; };',
         'var x: (number) => string',
         'var y: return',
         'var a: { x: number, y: string }',
@@ -189,7 +192,7 @@ module.exports = {
         'type FBID = number;',
         'type Foo<T> = Bar<T>',
     ],
-    'Interfaces': [
+    'Interfaces (module and script)': [
         'interface A {}',
         'interface A extends B {}',
         'interface A<T> extends B<T>, C<T> {}',

--- a/test/fbtest.js
+++ b/test/fbtest.js
@@ -191,6 +191,7 @@ module.exports = {
     'Type Alias': [
         'type FBID = number;',
         'type Foo<T> = Bar<T>',
+        'export type Foo = number;',
     ],
     'Interfaces (module and script)': [
         'interface A {}',

--- a/test/fbtest.rec.js
+++ b/test/fbtest.rec.js
@@ -4,7 +4,7 @@
 * tests/fbtest.js and run tools/generate-fbtest.js
 */
 
-var numTests = 204
+var numTests = 207
 var testFixture;
 
 var fbTestFixture = {
@@ -1958,14 +1958,6 @@ var fbTestFixture = {
                 end: { line: 1, column: 11 }
             }
         },
-        '<a .../*hai*/asdf/>': {
-            index: 3,
-            lineNumber: 1,
-            column: 4,
-            message: 'Error: Line 1: Unexpected token ...',
-            description: 'Unexpected token ...'
-
-        },
         '<a>= == =</a>': {
             type: 'ExpressionStatement',
             expression: {
@@ -2268,6 +2260,14 @@ var fbTestFixture = {
             column: 4,
             message: 'Error: Line 1: Unexpected token }',
             description: 'Unexpected token }'
+
+        },
+        '<a .../*hai*/asdf/>': {
+            index: 3,
+            lineNumber: 1,
+            column: 4,
+            message: 'Error: Line 1: Unexpected token ...',
+            description: 'Unexpected token ...'
 
         },
     },
@@ -5764,6 +5764,116 @@ var fbTestFixture = {
                 end: { line: 1, column: 40 }
             }
         },
+        'var a: { [a: number]: string; [b: number]: string; };': {
+            type: 'VariableDeclaration',
+            declarations: [{
+                type: 'VariableDeclarator',
+                id: {
+                    type: 'Identifier',
+                    name: 'a',
+                    typeAnnotation: {
+                        type: 'TypeAnnotation',
+                        typeAnnotation: {
+                            type: 'ObjectTypeAnnotation',
+                            properties: [],
+                            indexers: [{
+                                type: 'ObjectTypeIndexer',
+                                id: {
+                                    type: 'Identifier',
+                                    name: 'a',
+                                    range: [10, 11],
+                                    loc: {
+                                        start: { line: 1, column: 10 },
+                                        end: { line: 1, column: 11 }
+                                    }
+                                },
+                                key: {
+                                    type: 'NumberTypeAnnotation',
+                                    range: [13, 19],
+                                    loc: {
+                                        start: { line: 1, column: 13 },
+                                        end: { line: 1, column: 19 }
+                                    }
+                                },
+                                value: {
+                                    type: 'StringTypeAnnotation',
+                                    range: [22, 28],
+                                    loc: {
+                                        start: { line: 1, column: 22 },
+                                        end: { line: 1, column: 28 }
+                                    }
+                                },
+                                range: [9, 28],
+                                loc: {
+                                    start: { line: 1, column: 9 },
+                                    end: { line: 1, column: 28 }
+                                }
+                            }, {
+                                type: 'ObjectTypeIndexer',
+                                id: {
+                                    type: 'Identifier',
+                                    name: 'b',
+                                    range: [31, 32],
+                                    loc: {
+                                        start: { line: 1, column: 31 },
+                                        end: { line: 1, column: 32 }
+                                    }
+                                },
+                                key: {
+                                    type: 'NumberTypeAnnotation',
+                                    range: [34, 40],
+                                    loc: {
+                                        start: { line: 1, column: 34 },
+                                        end: { line: 1, column: 40 }
+                                    }
+                                },
+                                value: {
+                                    type: 'StringTypeAnnotation',
+                                    range: [43, 49],
+                                    loc: {
+                                        start: { line: 1, column: 43 },
+                                        end: { line: 1, column: 49 }
+                                    }
+                                },
+                                range: [30, 49],
+                                loc: {
+                                    start: { line: 1, column: 30 },
+                                    end: { line: 1, column: 49 }
+                                }
+                            }],
+                            callProperties: [],
+                            range: [7, 52],
+                            loc: {
+                                start: { line: 1, column: 7 },
+                                end: { line: 1, column: 52 }
+                            }
+                        },
+                        range: [5, 52],
+                        loc: {
+                            start: { line: 1, column: 5 },
+                            end: { line: 1, column: 52 }
+                        }
+                    },
+                    range: [4, 52],
+                    loc: {
+                        start: { line: 1, column: 4 },
+                        end: { line: 1, column: 52 }
+                    }
+                },
+                init: null,
+                range: [4, 52],
+                loc: {
+                    start: { line: 1, column: 4 },
+                    end: { line: 1, column: 52 }
+                }
+            }],
+            kind: 'var',
+            range: [0, 53],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 53 }
+            }
+        },
         'var a: {add(x:number, ...y:Array<string>): void}': {
             type: 'VariableDeclaration',
             declarations: [{
@@ -8981,6 +9091,141 @@ var fbTestFixture = {
                 end: { line: 1, column: 38 }
             }
         },
+        'import type foo from "bar";': {
+            type: 'ImportDeclaration',
+            specifiers: [{
+                type: 'ImportDefaultSpecifier',
+                id: {
+                    type: 'Identifier',
+                    name: 'foo',
+                    range: [12, 15],
+                    loc: {
+                        start: { line: 1, column: 12 },
+                        end: { line: 1, column: 15 }
+                    }
+                },
+                range: [12, 15],
+                loc: {
+                    start: { line: 1, column: 12 },
+                    end: { line: 1, column: 15 }
+                }
+            }],
+            source: {
+                type: 'ModuleSpecifier',
+                value: 'bar',
+                raw: '"bar"',
+                range: [21, 26],
+                loc: {
+                    start: { line: 1, column: 21 },
+                    end: { line: 1, column: 26 }
+                }
+            },
+            isType: true,
+            range: [0, 27],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 27 }
+            }
+        },
+        'import type {foo, bar} from "baz";': {
+            type: 'ImportDeclaration',
+            specifiers: [{
+                type: 'ImportSpecifier',
+                id: {
+                    type: 'Identifier',
+                    name: 'foo',
+                    range: [13, 16],
+                    loc: {
+                        start: { line: 1, column: 13 },
+                        end: { line: 1, column: 16 }
+                    }
+                },
+                name: null,
+                range: [13, 16],
+                loc: {
+                    start: { line: 1, column: 13 },
+                    end: { line: 1, column: 16 }
+                }
+            }, {
+                type: 'ImportSpecifier',
+                id: {
+                    type: 'Identifier',
+                    name: 'bar',
+                    range: [18, 21],
+                    loc: {
+                        start: { line: 1, column: 18 },
+                        end: { line: 1, column: 21 }
+                    }
+                },
+                name: null,
+                range: [18, 21],
+                loc: {
+                    start: { line: 1, column: 18 },
+                    end: { line: 1, column: 21 }
+                }
+            }],
+            source: {
+                type: 'ModuleSpecifier',
+                value: 'baz',
+                raw: '"baz"',
+                range: [28, 33],
+                loc: {
+                    start: { line: 1, column: 28 },
+                    end: { line: 1, column: 33 }
+                }
+            },
+            isType: true,
+            range: [0, 34],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 34 }
+            }
+        },
+        'import type {foo as bar} from "baz";': {
+            type: 'ImportDeclaration',
+            specifiers: [{
+                type: 'ImportSpecifier',
+                id: {
+                    type: 'Identifier',
+                    name: 'foo',
+                    range: [13, 16],
+                    loc: {
+                        start: { line: 1, column: 13 },
+                        end: { line: 1, column: 16 }
+                    }
+                },
+                name: {
+                    type: 'Identifier',
+                    name: 'bar',
+                    range: [20, 23],
+                    loc: {
+                        start: { line: 1, column: 20 },
+                        end: { line: 1, column: 23 }
+                    }
+                },
+                range: [13, 23],
+                loc: {
+                    start: { line: 1, column: 13 },
+                    end: { line: 1, column: 23 }
+                }
+            }],
+            source: {
+                type: 'ModuleSpecifier',
+                value: 'baz',
+                raw: '"baz"',
+                range: [30, 35],
+                loc: {
+                    start: { line: 1, column: 30 },
+                    end: { line: 1, column: 35 }
+                }
+            },
+            isType: true,
+            range: [0, 36],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 36 }
+            }
+        },
     },
     'Invalid Type Annotations': {
         'function foo(callback:) {}': {
@@ -9038,116 +9283,6 @@ var fbTestFixture = {
             message: 'Error: Line 1: Unexpected identifier',
             description: 'Unexpected identifier'
 
-        },
-        'var a: { [a: number]: string; [b: number]: string; };': {
-            type: 'VariableDeclaration',
-            declarations: [{
-                type: 'VariableDeclarator',
-                id: {
-                    type: 'Identifier',
-                    name: 'a',
-                    typeAnnotation: {
-                        type: 'TypeAnnotation',
-                        typeAnnotation: {
-                            type: 'ObjectTypeAnnotation',
-                            properties: [],
-                            indexers: [{
-                                type: 'ObjectTypeIndexer',
-                                id: {
-                                    type: 'Identifier',
-                                    name: 'a',
-                                    range: [10, 11],
-                                    loc: {
-                                        start: { line: 1, column: 10 },
-                                        end: { line: 1, column: 11 }
-                                    }
-                                },
-                                key: {
-                                    type: 'NumberTypeAnnotation',
-                                    range: [13, 19],
-                                    loc: {
-                                        start: { line: 1, column: 13 },
-                                        end: { line: 1, column: 19 }
-                                    }
-                                },
-                                value: {
-                                    type: 'StringTypeAnnotation',
-                                    range: [22, 28],
-                                    loc: {
-                                        start: { line: 1, column: 22 },
-                                        end: { line: 1, column: 28 }
-                                    }
-                                },
-                                range: [9, 28],
-                                loc: {
-                                    start: { line: 1, column: 9 },
-                                    end: { line: 1, column: 28 }
-                                }
-                            }, {
-                                type: 'ObjectTypeIndexer',
-                                id: {
-                                    type: 'Identifier',
-                                    name: 'b',
-                                    range: [31, 32],
-                                    loc: {
-                                        start: { line: 1, column: 31 },
-                                        end: { line: 1, column: 32 }
-                                    }
-                                },
-                                key: {
-                                    type: 'NumberTypeAnnotation',
-                                    range: [34, 40],
-                                    loc: {
-                                        start: { line: 1, column: 34 },
-                                        end: { line: 1, column: 40 }
-                                    }
-                                },
-                                value: {
-                                    type: 'StringTypeAnnotation',
-                                    range: [43, 49],
-                                    loc: {
-                                        start: { line: 1, column: 43 },
-                                        end: { line: 1, column: 49 }
-                                    }
-                                },
-                                range: [30, 49],
-                                loc: {
-                                    start: { line: 1, column: 30 },
-                                    end: { line: 1, column: 49 }
-                                }
-                            }],
-                            callProperties: [],
-                            range: [7, 52],
-                            loc: {
-                                start: { line: 1, column: 7 },
-                                end: { line: 1, column: 52 }
-                            }
-                        },
-                        range: [5, 52],
-                        loc: {
-                            start: { line: 1, column: 5 },
-                            end: { line: 1, column: 52 }
-                        }
-                    },
-                    range: [4, 52],
-                    loc: {
-                        start: { line: 1, column: 4 },
-                        end: { line: 1, column: 52 }
-                    }
-                },
-                init: null,
-                range: [4, 52],
-                loc: {
-                    start: { line: 1, column: 4 },
-                    end: { line: 1, column: 52 }
-                }
-            }],
-            kind: 'var',
-            range: [0, 53],
-            loc: {
-                start: { line: 1, column: 0 },
-                end: { line: 1, column: 53 }
-            }
         },
         'var x: (number) => string': {
             index: 15,
@@ -9951,7 +10086,7 @@ var fbTestFixture = {
             }
         },
     },
-    'Interfaces': {
+    'Interfaces (module and script)': {
         'interface A {}': {
             type: 'InterfaceDeclaration',
             id: {
@@ -10874,11 +11009,11 @@ var fbTestFixture = {
     },
     'Invalid Interfaces': {
         'interface {}': {
-            index: 10,
+            index: 0,
             lineNumber: 1,
-            column: 11,
-            message: 'Error: Line 1: Unexpected token {',
-            description: 'Unexpected token {'
+            column: 1,
+            message: 'Error: Line 1: Use of future reserved word in strict mode',
+            description: 'Use of future reserved word in strict mode'
 
         },
         'interface A extends {}': {
@@ -12910,6 +13045,11 @@ var fbTestFixture = {
                 throw new Error('FB test should not replace existing test for ' + i);
             }
             testFixture[i] = fixtures;
+            testFixtureOptions[i] = {sourceType: 'module'};
+
+            if (/( \(module and script\)$)/.test(i)) {
+              testFixture[i + ' (non-module)'] = fixtures;
+            }
         }
     }
     

--- a/test/fbtest.rec.js
+++ b/test/fbtest.rec.js
@@ -4,7 +4,7 @@
 * tests/fbtest.js and run tools/generate-fbtest.js
 */
 
-var numTests = 207
+var numTests = 208
 var testFixture;
 
 var fbTestFixture = {
@@ -10083,6 +10083,43 @@ var fbTestFixture = {
             loc: {
                 start: { line: 1, column: 0 },
                 end: { line: 1, column: 20 }
+            }
+        },
+        'export type Foo = number;': {
+            type: 'ExportDeclaration',
+            'default': false,
+            declaration: {
+                type: 'TypeAlias',
+                id: {
+                    type: 'Identifier',
+                    name: 'Foo',
+                    range: [12, 15],
+                    loc: {
+                        start: { line: 1, column: 12 },
+                        end: { line: 1, column: 15 }
+                    }
+                },
+                typeParameters: null,
+                right: {
+                    type: 'NumberTypeAnnotation',
+                    range: [18, 24],
+                    loc: {
+                        start: { line: 1, column: 18 },
+                        end: { line: 1, column: 24 }
+                    }
+                },
+                range: [7, 25],
+                loc: {
+                    start: { line: 1, column: 7 },
+                    end: { line: 1, column: 25 }
+                }
+            },
+            specifiers: [],
+            source: null,
+            range: [0, 25],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 25 }
             }
         },
     },

--- a/test/harmonymodulestest.js
+++ b/test/harmonymodulestest.js
@@ -1143,6 +1143,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 21 }
                 }
             },
+            isType: false,
             range: [0, 22],
             loc: {
                 start: { line: 1, column: 0 },
@@ -1187,6 +1188,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 34 }
                 }
             },
+            isType: false,
             range: [0, 35],
             loc: {
                 start: { line: 1, column: 0 },
@@ -1225,6 +1227,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 23 }
                 }
             },
+            isType: false,
             range: [0, 24],
             loc: {
                 start: { line: 1, column: 0 },
@@ -1278,6 +1281,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 28 }
                 }
             },
+            isType: false,
             range: [0, 29],
             loc: {
                 start: { line: 1, column: 0 },
@@ -1322,6 +1326,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 30 }
                 }
             },
+            isType: false,
             range: [0, 31],
             loc: {
                 start: { line: 1, column: 0 },
@@ -1383,6 +1388,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 35 }
                 }
             },
+            isType: false,
             range: [0, 36],
             loc: {
                 start: { line: 1, column: 0 },
@@ -1420,6 +1426,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 26 }
                 }
             },
+            isType: false,
             range: [0, 27],
             loc: {
                 start: { line: 1, column: 0 },
@@ -1441,6 +1448,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 12 }
                 }
             },
+            isType: false,
             range: [0, 13],
             loc: {
                 start: { line: 1, column: 0 },
@@ -1495,6 +1503,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 28 }
                 }
             },
+            isType: false,
             range: [0, 29],
             loc: {
                 start: { line: 1, column: 0 },
@@ -1548,6 +1557,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 31 }
                 }
             },
+            isType: false,
             range: [0, 32],
             loc: {
                 start: { line: 1, column: 0 },
@@ -2069,6 +2079,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 15 }
                 }
             },
+            isType: false,
             range: [0, 15],
             loc: {
                 start: { line: 1, column: 0 },
@@ -2105,6 +2116,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 22 }
                 }
             },
+            isType: false,
             range: [0, 22],
             loc: {
                 start: { line: 1, column: 0 },
@@ -2159,6 +2171,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 41 }
                 }
             },
+            isType: false,
             range: [0, 41],
             loc: {
                 start: { line: 1, column: 0 },
@@ -2204,6 +2217,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 39 }
                 }
             },
+            isType: false,
             range: [0, 39],
             loc: {
                 start: { line: 1, column: 0 },
@@ -2266,6 +2280,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 48 }
                 }
             },
+            isType: false,
             range: [0, 48],
             loc: {
                 start: { line: 1, column: 0 },
@@ -2311,6 +2326,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 33 }
                 }
             },
+            isType: false,
             range: [0, 33],
             loc: {
                 start: { line: 1, column: 0 },
@@ -2478,6 +2494,7 @@ var modulesTestFixture = {
                     end: { line: 1, column: 20 }
                 }
             },
+            isType: false,
             range: [0, 21],
             loc: {
                 start: { line: 1, column: 0 },
@@ -2614,6 +2631,7 @@ var modulesTestFixture = {
                                 end: { line: 1, column: 24 }
                             }
                         },
+                        isType: false,
                         range: [14, 25],
                         loc: {
                             start: { line: 1, column: 14 },

--- a/tools/generate-fbtest.js
+++ b/tools/generate-fbtest.js
@@ -22,6 +22,7 @@ var options = {
     comment: false,
     range: true,
     loc: true,
+    sourceType: 'module',
     tokens: false,
     raw: true,
     tolerant: false
@@ -103,6 +104,11 @@ out += "};\n\n\
                 throw new Error('FB test should not replace existing test for ' + i);\n\
             }\n\
             testFixture[i] = fixtures;\n\
+            testFixtureOptions[i] = {sourceType: 'module'};\n\
+\n\
+            if (/( \\(module and script\\)$)/.test(i)) {\n\
+              testFixture[i + ' (non-module)'] = fixtures;\n\
+            }\n\
         }\n\
     }\n\
     \n\


### PR DESCRIPTION
- Adds support for `import type` by add an `isType` flag to the `ImportDeclaration` node
- Adds support for type-alias declarations in the ExportDeclaration position (`export type foo = number`)
- Now runs all fb-tests in "module" mode (which really just means implicit strict mode + import/export)
- Adds support to the fb test generator to look for groups of fixtures that end in the magic string " (module and script)" in order to ensure that the string parses the same in both module mode and strict mode.
  - This helps with coverage and guarantees that stuff like ES reserved words in strict mode (like `interface`) parse correctly in both regular and strict mode for Flow
