### PR TITLE
Fix `import type from "foo";` ambiguity

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -4946,13 +4946,17 @@ parseYieldExpression: true, parseAwaitExpression: true
     }
 
     function parseImportDeclaration() {
-        var specifiers, src, marker = markerCreate(), isType = false;
+        var specifiers, src, marker = markerCreate(), isType = false, token2;
 
         expectKeyword('import');
 
         if (matchContextualKeyword('type')) {
-            isType = true;
-            lex();
+            token2 = lookahead2();
+            if ((token2.type === Token.Identifier && token2.value !== 'from') ||
+                    (token2.type === Token.Punctuator && token2.value === '{')) {
+                isType = true;
+                lex();
+            }
         }
 
         specifiers = [];

--- a/test/fbtest.js
+++ b/test/fbtest.js
@@ -160,7 +160,9 @@ module.exports = {
         'var identity: <T>(x: T, ...y:T[]) => T',
         'import type foo from "bar";',
         'import type {foo, bar} from "baz";',
-        'import type {foo as bar} from "baz";'
+        'import type {foo as bar} from "baz";',
+        'import type from "foo";',
+        'import type, {foo} from "bar";',
     ],
     'Invalid Type Annotations': [
         'function foo(callback:) {}',

--- a/test/fbtest.rec.js
+++ b/test/fbtest.rec.js
@@ -4,7 +4,7 @@
 * tests/fbtest.js and run tools/generate-fbtest.js
 */
 
-var numTests = 208
+var numTests = 210
 var testFixture;
 
 var fbTestFixture = {
@@ -9224,6 +9224,95 @@ var fbTestFixture = {
             loc: {
                 start: { line: 1, column: 0 },
                 end: { line: 1, column: 36 }
+            }
+        },
+        'import type from "foo";': {
+            type: 'ImportDeclaration',
+            specifiers: [{
+                type: 'ImportDefaultSpecifier',
+                id: {
+                    type: 'Identifier',
+                    name: 'type',
+                    range: [7, 11],
+                    loc: {
+                        start: { line: 1, column: 7 },
+                        end: { line: 1, column: 11 }
+                    }
+                },
+                range: [7, 11],
+                loc: {
+                    start: { line: 1, column: 7 },
+                    end: { line: 1, column: 11 }
+                }
+            }],
+            source: {
+                type: 'ModuleSpecifier',
+                value: 'foo',
+                raw: '"foo"',
+                range: [17, 22],
+                loc: {
+                    start: { line: 1, column: 17 },
+                    end: { line: 1, column: 22 }
+                }
+            },
+            isType: false,
+            range: [0, 23],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 23 }
+            }
+        },
+        'import type, {foo} from "bar";': {
+            type: 'ImportDeclaration',
+            specifiers: [{
+                type: 'ImportDefaultSpecifier',
+                id: {
+                    type: 'Identifier',
+                    name: 'type',
+                    range: [7, 11],
+                    loc: {
+                        start: { line: 1, column: 7 },
+                        end: { line: 1, column: 11 }
+                    }
+                },
+                range: [7, 11],
+                loc: {
+                    start: { line: 1, column: 7 },
+                    end: { line: 1, column: 11 }
+                }
+            }, {
+                type: 'ImportSpecifier',
+                id: {
+                    type: 'Identifier',
+                    name: 'foo',
+                    range: [14, 17],
+                    loc: {
+                        start: { line: 1, column: 14 },
+                        end: { line: 1, column: 17 }
+                    }
+                },
+                name: null,
+                range: [14, 17],
+                loc: {
+                    start: { line: 1, column: 14 },
+                    end: { line: 1, column: 17 }
+                }
+            }],
+            source: {
+                type: 'ModuleSpecifier',
+                value: 'bar',
+                raw: '"bar"',
+                range: [24, 29],
+                loc: {
+                    start: { line: 1, column: 24 },
+                    end: { line: 1, column: 29 }
+                }
+            },
+            isType: false,
+            range: [0, 30],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 30 }
             }
         },
     },


### PR DESCRIPTION
In https://github.com/facebook/esprima/pull/92 I added support for `import type`, but didn't propertly disambiguate `import type from "foo";`. This fixes that up
