### PR TITLE
Added support of void elements

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -2393,8 +2393,7 @@
                 type: Syntax.JSXOpeningElement,
                 name: name,
                 selfClosing: selfClosing || !!VoidElements[name.name],
-                attributes: attributes,
-                isVoid: !!VoidElements[name.name]
+                attributes: attributes
             };
         },
 

--- a/esprima.js
+++ b/esprima.js
@@ -6566,7 +6566,7 @@
         source: 1,
         track: 1,
         wbr: 1
-    }
+    };
 
 
     XHTMLEntities = {

--- a/esprima.js
+++ b/esprima.js
@@ -56,6 +56,7 @@
         Regex,
         SyntaxTreeDelegate,
         XHTMLEntities,
+        VoidElements,
         ClassPropertyType,
         source,
         strict,
@@ -2391,8 +2392,9 @@
             return {
                 type: Syntax.JSXOpeningElement,
                 name: name,
-                selfClosing: selfClosing,
-                attributes: attributes
+                selfClosing: selfClosing || !!VoidElements[name.name],
+                attributes: attributes,
+                isVoid: !!VoidElements[name.name]
             };
         },
 
@@ -6549,6 +6551,24 @@
     }
 
     // 16 JSX
+    VoidElements = {
+        area: 1,
+        base: 1,
+        br: 1,
+        col: 1,
+        embed: 1,
+        hr: 1,
+        img: 1,
+        input: 1,
+        keygen: 1,
+        link: 1,
+        meta: 1,
+        param: 1,
+        source: 1,
+        track: 1,
+        wbr: 1
+    }
+
 
     XHTMLEntities = {
         quot: '\u0022',


### PR DESCRIPTION
Hi Team
Few months ago I started React review. In general it was good impression, but one thing wondered me.
Why I must close all tags. I mean tags like br, img. This tags do not require closing slash and it is described in HTML5 specification:
http://www.w3.org/TR/html-markup/syntax.html -> chapter 4.3
My marks here -> http://take.ms/QdAfS
My pool request fixes this problem by automate adding selfClosing mark for all Void Elements
Already tested on live production.

Alex. 
