### PR TITLE
Add tests to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@
 /demo/
 /test/3rdparty
 /tools/
+/test


### PR DESCRIPTION
Tests take > 1 Mo in space, maybe we shouldn't ship them to npm ?
