### PR TITLE
Added Keywords to Package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,14 @@
         "json-diff": "~0.3.1",
         "commander": "~2.5.0"
     },
+    "keywords": {
+	"ecmascript",
+	"parser",
+	"javascript",
+	"es6",
+	"harmony",
+	"JSX"
+    },
     "scripts": {
         "generate-regex": "node tools/generate-identifier-regex.js",
 

--- a/package.json
+++ b/package.json
@@ -51,14 +51,14 @@
         "json-diff": "~0.3.1",
         "commander": "~2.5.0"
     },
-    "keywords": {
+    "keywords": [
 	"ecmascript",
 	"parser",
 	"javascript",
 	"es6",
 	"harmony",
 	"JSX"
-    },
+    ],
     "scripts": {
         "generate-regex": "node tools/generate-identifier-regex.js",
 


### PR DESCRIPTION
I'm doing minor beginner changes to repositories for school. The task was to find repositories that contain package.json files that have missing keywords. I've added the keywords to the json file.
"keywords": [
	"ecmascript",
	"parser",
	"javascript",
	"es6",
	"harmony",
	"JSX"
    ],
<img width="898" alt="screen shot 2017-01-20 at 1 16 42 pm" src="https://cloud.githubusercontent.com/assets/3598286/22160280/b678a740-df12-11e6-8bcc-3a72a1b62e81.png">
 
I've also included a quick screenshot. Let me know if anything is out of line, missing or wrong.

Regards!