### PR TITLE
Add entire test directory to NPM ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,5 +4,5 @@
 /assets/
 /coverage/
 /demo/
-/test/3rdparty
+/test/
 /tools/


### PR DESCRIPTION
I'd noticed that esprima-fb includes the `test` directory in their NPM package, and it has a bit of weight to it:

```
➜  test_size git:(master) du -sh ./node_modules/esprima-fb/test
816K    ./node_modules/esprima-fb/test
```

In a clean install of EmberJS this is included twice, adding an extra 1.6M to the `node_modules` size. As it's a common package I could see this spanning into multiple more inclusions.

Would you consider excluding the `test` directory from the `esprima-fb` package?

Thank you for your time in reading!